### PR TITLE
fix: code review round 3 — thread safety, perf, cleanup

### DIFF
--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -100,7 +100,7 @@ final class RecordingEngine: ObservableObject {
             }
         } catch {
             errorMessage = "Failed to start recording: \(error.localizedDescription)"
-            await cleanup()
+            cleanup()
         }
     }
 
@@ -115,7 +115,7 @@ final class RecordingEngine: ObservableObject {
         audioWriter?.finalize()
 
         let url = audioWriter?.outputURL
-        await cleanup()
+        cleanup()
 
         isRecording = false
         duration = 0
@@ -134,7 +134,7 @@ final class RecordingEngine: ObservableObject {
         }
     }
 
-    private func cleanup() async {
+    private func cleanup() {
         audioWriter = nil
         recordingStartTime = nil
     }

--- a/EchoNotes/Audio/AudioFileWriter.swift
+++ b/EchoNotes/Audio/AudioFileWriter.swift
@@ -88,8 +88,16 @@ final class AudioFileWriter: @unchecked Sendable {
             channelData[1][i] = micSamples[i]
         }
 
-        systemSamples.removeFirst(count)
-        micSamples.removeFirst(count)
+        if count == systemSamples.count {
+            systemSamples.removeAll(keepingCapacity: true)
+        } else {
+            systemSamples.removeFirst(count)
+        }
+        if count == micSamples.count {
+            micSamples.removeAll(keepingCapacity: true)
+        } else {
+            micSamples.removeFirst(count)
+        }
 
         do {
             try file.write(from: pcmBuffer)

--- a/EchoNotes/Audio/SystemAudioCapture.swift
+++ b/EchoNotes/Audio/SystemAudioCapture.swift
@@ -1,6 +1,7 @@
 import ScreenCaptureKit
 import AVFoundation
 import CoreMedia
+import os
 
 /// Captures system-wide audio output using ScreenCaptureKit's audio API.
 ///
@@ -16,11 +17,11 @@ final class SystemAudioCapture: NSObject, @unchecked Sendable {
     var onError: ((Error) -> Void)?
 
     private var stream: SCStream?
-    private var isCapturing = false
+    private let _isCapturing = OSAllocatedUnfairLock(initialState: false)
 
     /// Start capturing system audio at the given sample rate (mono Float32).
     func startCapture(sampleRate: Double = 48000) async throws {
-        guard !isCapturing else { return }
+        guard _isCapturing.withLock({ !$0 }) else { return }
 
         let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
         guard let display = content.displays.first else {
@@ -47,14 +48,14 @@ final class SystemAudioCapture: NSObject, @unchecked Sendable {
         try await stream.startCapture()
 
         self.stream = stream
-        isCapturing = true
+        _isCapturing.withLock { $0 = true }
     }
 
     func stopCapture() async {
-        guard isCapturing, let stream else { return }
+        guard _isCapturing.withLock({ $0 }), let stream else { return }
         try? await stream.stopCapture()
         self.stream = nil
-        isCapturing = false
+        _isCapturing.withLock { $0 = false }
     }
 }
 
@@ -87,7 +88,7 @@ extension SystemAudioCapture: SCStreamOutput {
 extension SystemAudioCapture: SCStreamDelegate {
     func stream(_ stream: SCStream, didStopWithError error: Error) {
         print("System audio stream error: \(error)")
-        isCapturing = false
+        _isCapturing.withLock { $0 = false }
         onError?(error)
     }
 }

--- a/EchoNotes/Transcription/WhisperEngine.swift
+++ b/EchoNotes/Transcription/WhisperEngine.swift
@@ -50,22 +50,15 @@ final class WhisperEngine: @unchecked Sendable {
         // Convert M4A → 16kHz mono Float32 PCM (left channel only)
         let samples = try await convertAudioToWhisperFormat(audioURL: audioURL)
 
-        // Run inference on a background thread
+        // Run inference off the main thread
         let ctx = context
-        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[TranscriptSegment], Error>) in
-            DispatchQueue.global(qos: .userInitiated).async {
-                do {
-                    let segments = try Self.runInference(
-                        context: ctx,
-                        samples: samples,
-                        progressCallback: progressCallback
-                    )
-                    continuation.resume(returning: segments)
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+        return try await Task.detached(priority: .userInitiated) {
+            try Self.runInference(
+                context: ctx,
+                samples: samples,
+                progressCallback: progressCallback
+            )
+        }.value
     }
 
     /// Convert an M4A file to 16kHz mono Float32 PCM, extracting the left channel.


### PR DESCRIPTION
## Changes

**Bugs fixed:**
- **SystemAudioCapture.isCapturing race condition** — was a plain bool read/written from multiple threads. Now uses OSAllocatedUnfairLock for proper synchronization.

**Performance:**
- **AudioFileWriter buffer clearing** — when both buffers are fully consumed (the common case), uses removeAll(keepingCapacity: true) instead of removeFirst(count) which is O(n) due to element shifting.

**Cleanup:**
- **RecordingEngine.cleanup()** — removed unnecessary async (just sets properties to nil)
- **WhisperEngine inference** — replaced DispatchQueue + CheckedContinuation with Task.detached (idiomatic Swift concurrency)

27 tests passing, builds clean.