### PR TITLE
fix: code review round 4 — progress, thread safety, cleanup

### DIFF
--- a/EchoNotes/App/AppDelegate.swift
+++ b/EchoNotes/App/AppDelegate.swift
@@ -18,10 +18,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Pre-download Whisper model on first launch if not already cached
         Task {
-            let manager = recorder.transcriptionManager.modelManager
-            let model = recorder.transcriptionManager.selectedModel
-            if !ModelManager.modelExists(model) {
-                _ = try? await manager.ensureEngine(for: model)
+            if !ModelManager.modelLikelyCached() {
+                _ = try? await recorder.transcriptionManager.modelManager.ensureEngine(
+                    for: recorder.transcriptionManager.selectedModel
+                )
             }
         }
     }

--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -2,7 +2,6 @@ import Foundation
 import SwiftUI
 import AppKit
 import AVFoundation
-import Combine
 
 /// Central recording engine — coordinates system audio + mic capture and writes to file.
 @MainActor

--- a/EchoNotes/Audio/MicrophoneCapture.swift
+++ b/EchoNotes/Audio/MicrophoneCapture.swift
@@ -1,4 +1,5 @@
-import AVFoundation
+@preconcurrency import AVFoundation
+import os
 
 /// Captures microphone audio using AVAudioEngine.
 /// Outputs mono Float32 PCM at the requested sample rate.
@@ -8,10 +9,10 @@ final class MicrophoneCapture: @unchecked Sendable {
     private let engine = AVAudioEngine()
     private var converter: AVAudioConverter?
     private var targetFormat: AVAudioFormat!
-    private var isCapturing = false
+    private let _isCapturing = OSAllocatedUnfairLock(initialState: false)
 
     func startCapture(sampleRate: Double = 48000) throws {
-        guard !isCapturing else { return }
+        guard _isCapturing.withLock({ !$0 }) else { return }
 
         targetFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: sampleRate, channels: 1, interleaved: false)!
 
@@ -28,14 +29,14 @@ final class MicrophoneCapture: @unchecked Sendable {
 
         engine.prepare()
         try engine.start()
-        isCapturing = true
+        _isCapturing.withLock { $0 = true }
     }
 
     func stopCapture() {
-        guard isCapturing else { return }
+        guard _isCapturing.withLock({ $0 }) else { return }
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
-        isCapturing = false
+        _isCapturing.withLock { $0 = false }
     }
 
     private func processBuffer(_ buffer: AVAudioPCMBuffer, time: AVAudioTime) {

--- a/EchoNotes/Transcription/ModelManager.swift
+++ b/EchoNotes/Transcription/ModelManager.swift
@@ -63,10 +63,9 @@ final class ModelManager: ObservableObject {
         }
     }
 
-    /// Check if a model is likely cached (WhisperKit manages its own cache).
-    nonisolated static func modelExists(_ model: WhisperModel) -> Bool {
-        // WhisperKit handles caching internally — this is a best-effort check
-        // by looking for the model folder in the default cache location
+    /// Check if WhisperKit models are likely cached.
+    /// Best-effort — WhisperKit manages its own cache; we just check if the directory exists.
+    nonisolated static func modelLikelyCached() -> Bool {
         let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         let modelDir = cacheDir.appendingPathComponent("huggingface/models/argmaxinc/whisperkit-coreml")
         return FileManager.default.fileExists(atPath: modelDir.path)

--- a/EchoNotes/Transcription/WhisperEngine.swift
+++ b/EchoNotes/Transcription/WhisperEngine.swift
@@ -2,7 +2,6 @@ import Foundation
 import WhisperKit
 
 /// Wraps WhisperKit for on-device speech-to-text.
-/// Handles both file-based and direct sample transcription.
 final class WhisperEngine: @unchecked Sendable {
     private let whisperKit: WhisperKit
 
@@ -15,24 +14,31 @@ final class WhisperEngine: @unchecked Sendable {
         audioURL: URL,
         progressCallback: (@Sendable (Double) -> Void)? = nil
     ) async throws -> [TranscriptSegment] {
-        let result = try await whisperKit.transcribe(audioPath: audioURL.path)
+        let result = try await whisperKit.transcribe(
+            audioPath: audioURL.path,
+            callback: { progress in
+                // Approximate progress from window position vs total audio
+                let audioSeconds = progress.timings.inputAudioSeconds
+                if audioSeconds > 0 {
+                    let processed = Double(progress.windowId + 1) * 30.0
+                    progressCallback?(min(processed / audioSeconds, 0.99))
+                }
+                return nil // continue transcription
+            }
+        )
 
         progressCallback?(1.0)
-
-        return result.flatMap { $0.segments.map { segment in
-            TranscriptSegment(
-                startTime: Double(segment.start),
-                endTime: Double(segment.end),
-                text: segment.text
-            )
-        }}
+        return mapResults(result)
     }
 
     /// Transcribe raw 16kHz mono Float32 PCM samples.
     func transcribeSamples(_ samples: [Float]) async throws -> [TranscriptSegment] {
         let result = try await whisperKit.transcribe(audioArray: samples)
+        return mapResults(result)
+    }
 
-        return result.flatMap { $0.segments.map { segment in
+    private func mapResults(_ results: [TranscriptionResult]) -> [TranscriptSegment] {
+        results.flatMap { $0.segments.map { segment in
             TranscriptSegment(
                 startTime: Double(segment.start),
                 endTime: Double(segment.end),

--- a/EchoNotesTests/ModelManagerTests.swift
+++ b/EchoNotesTests/ModelManagerTests.swift
@@ -18,9 +18,9 @@ struct ModelManagerTests {
         #expect(Set(rawValues).count == rawValues.count)
     }
 
-    @Test("Model existence check doesn't crash")
-    func modelExistsCheck() {
+    @Test("Cache check doesn't crash")
+    func cacheCheck() {
         // Just ensure it doesn't crash — result is non-deterministic
-        _ = ModelManager.modelExists(.tiny)
+        _ = ModelManager.modelLikelyCached()
     }
 }


### PR DESCRIPTION
## Fixes

1. **Post-recording progress bar was broken** — hooked into WhisperKit's `TranscriptionCallback` to report real progress based on decoding window position vs total audio duration. Was stuck at 0% then jumping to 100%.

2. **MicrophoneCapture thread safety** — `isCapturing` was a plain bool (inconsistent with SystemAudioCapture which already uses `OSAllocatedUnfairLock`). Fixed.

3. **ModelManager.modelExists checked wrong path** — renamed to `modelLikelyCached()` and clarified it's best-effort since WhisperKit manages its own cache.

4. **Duplicate segment mapping** — extracted into `mapResults()` helper in WhisperEngine.

5. **Unused import** — removed `Combine` from RecordingEngine.

32 tests passing, builds clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transcription progress reporting during audio processing.

* **Bug Fixes**
  * Improved microphone capture stability and reliability.
  * Optimized app startup by detecting previously downloaded models more efficiently.

* **Tests**
  * Updated tests for recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->