### PR TITLE
Fix review round 2: error handling, performance, and UX improvements

### DIFF
--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -40,6 +40,8 @@ final class RecordingEngine: ObservableObject {
     private var audioWriter: AudioFileWriter?
     private var durationTimer: Timer?
     private var recordingStartTime: Date?
+    private var lastSystemLevelUpdate: Date = .distantPast
+    private var lastMicLevelUpdate: Date = .distantPast
 
     /// Save location for recordings. Directory validation happens in startRecording().
     var saveDirectory: URL {
@@ -52,8 +54,7 @@ final class RecordingEngine: ObservableObject {
         errorMessage = nil
 
         // Check permissions
-        let permissions = PermissionChecker()
-        if let permissionError = await permissions.checkPermissionsWithMessage() {
+        if let permissionError = await PermissionChecker.checkPermissionsWithMessage() {
             errorMessage = permissionError
             return
         }
@@ -66,9 +67,11 @@ final class RecordingEngine: ObservableObject {
             return
         }
 
-        // Create output file
-        let timestamp = ISO8601DateFormatter().string(from: Date())
-            .replacingOccurrences(of: ":", with: "-")
+        // Create output file with local timezone timestamp
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        formatter.timeZone = TimeZone.current
+        let timestamp = formatter.string(from: Date())
         let filename = "recording-\(timestamp).m4a"
         let fileURL = saveDirectory.appendingPathComponent(filename)
 
@@ -83,10 +86,17 @@ final class RecordingEngine: ObservableObject {
 
             audioWriter = writer
 
-            // Surface system audio capture errors to the UI
+            // Surface audio capture errors to the UI
             systemCapture.onError = { [weak self] error in
                 Task { @MainActor in
                     self?.errorMessage = "System audio error: \(error.localizedDescription)"
+                    await self?.stopRecording()
+                }
+            }
+
+            micCapture.onError = { [weak self] error in
+                Task { @MainActor in
+                    self?.errorMessage = "Microphone error: \(error.localizedDescription)"
                     await self?.stopRecording()
                 }
             }
@@ -104,25 +114,9 @@ final class RecordingEngine: ObservableObject {
                 }
             }
 
-            // Start captures with callbacks that feed the writer
-            systemCapture.onBuffer = { [weak self] buffer in
-                self?.audioWriter?.writeSystemBuffer(buffer)
-                // Feed system audio to streaming transcriber for live mode
-                if isLive {
-                    self?.transcriptionManager.streamingTranscriber.feedSamples(buffer.samples)
-                }
-                Task { @MainActor in
-                    self?.systemLevel = SourcedAudioBuffer.rmsLevel(buffer.samples)
-                }
-            }
-
-            micCapture.onBuffer = { [weak self] buffer in
-                self?.audioWriter?.writeMicBuffer(buffer)
-                Task { @MainActor in
-                    self?.micLevel = SourcedAudioBuffer.rmsLevel(buffer.samples)
-                }
-            }
-
+            // Start both captures BEFORE setting onBuffer callbacks
+            // This prevents partial failure states where system buffers feed a writer
+            // that's about to be finalized
             try await systemCapture.startCapture(sampleRate: AudioConfig.sampleRate)
             do {
                 try micCapture.startCapture(sampleRate: AudioConfig.sampleRate)
@@ -130,6 +124,37 @@ final class RecordingEngine: ObservableObject {
                 // System capture already started — must stop it before bailing
                 await systemCapture.stopCapture()
                 throw error
+            }
+
+            // Now that both captures are running, set up buffer callbacks
+            systemCapture.onBuffer = { [weak self] buffer in
+                self?.audioWriter?.writeSystemBuffer(buffer)
+                // Feed system audio to streaming transcriber for live mode
+                if isLive {
+                    self?.transcriptionManager.streamingTranscriber.feedSamples(buffer.samples)
+                }
+                // Throttle level meter updates to ~15fps (66ms minimum interval)
+                Task { @MainActor in
+                    guard let self else { return }
+                    let now = Date()
+                    if now.timeIntervalSince(self.lastSystemLevelUpdate) > 0.066 {
+                        self.systemLevel = SourcedAudioBuffer.rmsLevel(buffer.samples)
+                        self.lastSystemLevelUpdate = now
+                    }
+                }
+            }
+
+            micCapture.onBuffer = { [weak self] buffer in
+                self?.audioWriter?.writeMicBuffer(buffer)
+                // Throttle level meter updates to ~15fps (66ms minimum interval)
+                Task { @MainActor in
+                    guard let self else { return }
+                    let now = Date()
+                    if now.timeIntervalSince(self.lastMicLevelUpdate) > 0.066 {
+                        self.micLevel = SourcedAudioBuffer.rmsLevel(buffer.samples)
+                        self.lastMicLevelUpdate = now
+                    }
+                }
             }
 
             recordingStartTime = Date()

--- a/EchoNotes/Audio/MicrophoneCapture.swift
+++ b/EchoNotes/Audio/MicrophoneCapture.swift
@@ -5,6 +5,7 @@ import os
 /// Outputs mono Float32 PCM at the requested sample rate.
 final class MicrophoneCapture: @unchecked Sendable {
     var onBuffer: ((SourcedAudioBuffer) -> Void)?
+    var onError: ((Error) -> Void)?
 
     private let engine = AVAudioEngine()
     private let lock = NSLock()
@@ -12,6 +13,7 @@ final class MicrophoneCapture: @unchecked Sendable {
     private var targetFormat: AVAudioFormat?
     private let _isCapturing = OSAllocatedUnfairLock(initialState: false)
     private let logger = Logger(subsystem: "com.echonotes", category: "MicrophoneCapture")
+    private var configObserver: NSObjectProtocol?
 
     func startCapture(sampleRate: Double = AudioConfig.sampleRate) throws {
         guard _isCapturing.withLock({ !$0 }) else { return }
@@ -34,6 +36,22 @@ final class MicrophoneCapture: @unchecked Sendable {
             self?.processBuffer(buffer)
         }
 
+        // Monitor for configuration changes (device disconnect, etc.)
+        configObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            // Check if engine stopped unexpectedly
+            if !self.engine.isRunning && self._isCapturing.withLock({ $0 }) {
+                let error = MicrophoneError.deviceDisconnected
+                self.logger.error("Microphone configuration changed, engine stopped: \(error.localizedDescription)")
+                self._isCapturing.withLock { $0 = false }
+                self.onError?(error)
+            }
+        }
+
         engine.prepare()
         try engine.start()
         _isCapturing.withLock { $0 = true }
@@ -41,6 +59,12 @@ final class MicrophoneCapture: @unchecked Sendable {
 
     func stopCapture() {
         guard _isCapturing.withLock({ $0 }) else { return }
+        
+        if let observer = configObserver {
+            NotificationCenter.default.removeObserver(observer)
+            configObserver = nil
+        }
+        
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
 
@@ -86,11 +110,12 @@ final class MicrophoneCapture: @unchecked Sendable {
 }
 
 enum MicrophoneError: LocalizedError {
-    case noInputDevice, converterCreationFailed
+    case noInputDevice, converterCreationFailed, deviceDisconnected
     var errorDescription: String? {
         switch self {
         case .noInputDevice: return "No microphone found."
         case .converterCreationFailed: return "Failed to create audio converter."
+        case .deviceDisconnected: return "Microphone disconnected during recording."
         }
     }
 }

--- a/EchoNotes/Audio/SystemAudioCapture.swift
+++ b/EchoNotes/Audio/SystemAudioCapture.swift
@@ -39,6 +39,9 @@ final class SystemAudioCapture: NSObject, @unchecked Sendable {
         config.excludesCurrentProcessAudio = true
 
         // Set minimal video config (we only register for .audio output, so no video data is processed)
+        // ScreenCaptureKit requires a video configuration even for audio-only capture.
+        // We use the smallest possible dimensions (2x2) to minimize overhead.
+        // If 2x2 fails on some systems, we fallback to 16x16.
         config.width = 2
         config.height = 2
         config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
@@ -46,7 +49,16 @@ final class SystemAudioCapture: NSObject, @unchecked Sendable {
 
         let stream = SCStream(filter: filter, configuration: config, delegate: self)
         try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: .global(qos: .userInteractive))
-        try await stream.startCapture()
+        
+        // Try to start with 2x2, fallback to 16x16 if it fails
+        do {
+            try await stream.startCapture()
+        } catch {
+            logger.warning("Failed to start capture with 2x2 config, retrying with 16x16: \(error.localizedDescription)")
+            config.width = 16
+            config.height = 16
+            try await stream.startCapture()
+        }
 
         self.stream = stream
         _isCapturing.withLock { $0 = true }
@@ -69,15 +81,13 @@ extension SystemAudioCapture: SCStreamOutput {
         guard let dataBuffer = sampleBuffer.dataBuffer else { return }
 
         let length = dataBuffer.dataLength
+        let floatCount = length / MemoryLayout<Float>.size
 
         do {
-            var rawData = Data(count: length)
-            try rawData.withUnsafeMutableBytes { ptr in
-                try dataBuffer.copyDataBytes(to: ptr)
-            }
-            let floatCount = length / MemoryLayout<Float>.size
-            let samples = rawData.withUnsafeBytes { ptr in
-                Array(ptr.bindMemory(to: Float.self).prefix(floatCount))
+            // Single-copy approach: access buffer bytes directly without intermediate Data allocation
+            let samples = try dataBuffer.withContiguousStorage { ptr in
+                Array(UnsafeBufferPointer(start: ptr.baseAddress?.assumingMemoryBound(to: Float.self),
+                                          count: floatCount))
             }
             onBuffer?(SourcedAudioBuffer(samples: samples, source: .system))
         } catch {

--- a/EchoNotes/Transcription/ModelManager.swift
+++ b/EchoNotes/Transcription/ModelManager.swift
@@ -37,6 +37,7 @@ final class ModelManager: ObservableObject {
 
     private var whisperKit: WhisperKit?
     private var loadedModel: WhisperModel?
+    private var progressMonitorTask: Task<Void, Never>?
 
     /// Get a ready-to-use WhisperEngine, downloading the model if needed.
     func ensureEngine(for model: WhisperModel) async throws -> WhisperEngine {
@@ -48,9 +49,16 @@ final class ModelManager: ObservableObject {
         downloadProgress = 0
         error = nil
 
-        defer { isDownloading = false }
+        defer { 
+            isDownloading = false
+            progressMonitorTask?.cancel()
+            progressMonitorTask = nil
+        }
 
         do {
+            // Start monitoring download progress
+            monitorDownloadProgress(for: model)
+            
             let config = WhisperKitConfig(model: model.rawValue)
             let kit = try await WhisperKit(config)
             self.whisperKit = kit
@@ -69,5 +77,40 @@ final class ModelManager: ObservableObject {
         let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         let modelDir = cacheDir.appendingPathComponent("huggingface/models/argmaxinc/whisperkit-coreml")
         return FileManager.default.fileExists(atPath: modelDir.path)
+    }
+
+    /// Monitor download progress by polling cache directory size.
+    /// Updates `downloadProgress` based on actual bytes downloaded vs expected model size.
+    private func monitorDownloadProgress(for model: WhisperModel) {
+        let expectedBytes = Int64(model.approximateSizeMB) * 1024 * 1024
+        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let modelDir = cacheDir.appendingPathComponent("huggingface/models/argmaxinc/whisperkit-coreml")
+        
+        progressMonitorTask = Task { @MainActor in
+            while !Task.isCancelled {
+                let currentSize = directorySize(at: modelDir)
+                let progress = min(0.99, Double(currentSize) / Double(expectedBytes))
+                self.downloadProgress = progress
+                
+                try? await Task.sleep(nanoseconds: 500_000_000) // 500ms
+            }
+        }
+    }
+
+    /// Calculate total size of a directory and its contents.
+    private nonisolated func directorySize(at url: URL) -> Int64 {
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return 0 }
+        
+        var totalSize: Int64 = 0
+        for case let fileURL as URL in enumerator {
+            guard let resourceValues = try? fileURL.resourceValues(forKeys: [.fileSizeKey]),
+                  let fileSize = resourceValues.fileSize else { continue }
+            totalSize += Int64(fileSize)
+        }
+        return totalSize
     }
 }

--- a/EchoNotes/Transcription/StreamingTranscriber.swift
+++ b/EchoNotes/Transcription/StreamingTranscriber.swift
@@ -138,6 +138,7 @@ final class StreamingTranscriber: ObservableObject {
             isProcessing = false
             
             // Drain queued samples with while-loop instead of recursion
+            // Use defer to ensure isProcessing is always reset, even on error/break
             while !queuedSamples.isEmpty {
                 let queued = queuedSamples
                 queuedSamples = []
@@ -145,6 +146,8 @@ final class StreamingTranscriber: ObservableObject {
                 let queuedTimeOffset = Double(totalSamplesProcessed) / sampleRate
                 totalSamplesProcessed += queued.count
                 isProcessing = true
+                
+                defer { isProcessing = false }
                 
                 do {
                     let resampled = try resample(queued)
@@ -162,8 +165,6 @@ final class StreamingTranscriber: ObservableObject {
                     self.error = "Live transcription error: \(error.localizedDescription)"
                     break
                 }
-                
-                isProcessing = false
             }
         }
     }

--- a/EchoNotes/Utils/Permissions.swift
+++ b/EchoNotes/Utils/Permissions.swift
@@ -6,7 +6,7 @@ import ScreenCaptureKit
 /// **Note:** "Screen Recording" permission is required to use ScreenCaptureKit's audio API.
 /// We use ScreenCaptureKit in AUDIO-ONLY mode — no video, screen, or visual data is captured.
 struct PermissionChecker {
-    func requestMicrophonePermission() async -> Bool {
+    private static func requestMicrophonePermission() async -> Bool {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)
         switch status {
         case .authorized: return true
@@ -15,21 +15,15 @@ struct PermissionChecker {
         }
     }
 
-    func requestScreenRecordingPermission() async -> Bool {
+    private static func requestScreenRecordingPermission() async -> Bool {
         do {
             _ = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
             return true
         } catch { return false }
     }
-
-    func ensureAllPermissions() async -> Bool {
-        let mic = await requestMicrophonePermission()
-        let screen = await requestScreenRecordingPermission()
-        return mic && screen
-    }
     
     /// Check permissions individually and return a specific error message if any are missing.
-    func checkPermissionsWithMessage() async -> String? {
+    static func checkPermissionsWithMessage() async -> String? {
         let mic = await requestMicrophonePermission()
         let screen = await requestScreenRecordingPermission()
         

--- a/EchoNotes/Views/RecordingControlsView.swift
+++ b/EchoNotes/Views/RecordingControlsView.swift
@@ -33,8 +33,8 @@ struct RecordingControlsView: View {
     
     private var shouldShowPrimaryButton: Bool {
         recorder.isRecording || 
-        recorder.lastRecordingURL == nil && 
-        !recorder.transcriptionManager.isTranscribing && 
-        recorder.transcriptionManager.transcript == nil
+        (recorder.lastRecordingURL == nil && 
+         !recorder.transcriptionManager.isTranscribing && 
+         recorder.transcriptionManager.transcript == nil)
     }
 }


### PR DESCRIPTION
This PR addresses all issues identified in the second review round, focusing on robustness, performance optimizations, and better user experience.

## Issues Fixed

### Error Handling & Robustness
- **Fixes #47**: Add fallback for ScreenCaptureKit 2x2 config with 16x16 retry + explanatory doc comment
- **Fixes #49**: Ensure `isProcessing` is always reset in StreamingTranscriber using defer
- **Fixes #50**: Move `onBuffer` callbacks AFTER both captures succeed to prevent partial failure states
- **Fixes #51**: Add `onError` callback to MicrophoneCapture with AVAudioEngine configuration change monitoring

### Performance Optimizations
- **Fixes #52**: Optimize SystemAudioCapture to use single-copy buffer access (eliminate intermediate Data allocation)
- **Fixes #53**: Throttle level meter updates to ~15fps (66ms interval) to reduce excessive MainActor hops

### Code Quality & UX
- **Fixes #48**: Add granular download progress monitoring for ModelManager (polls cache directory every 500ms)
- **Fixes #54**: Convert PermissionChecker to use static methods (stateless struct pattern)
- **Fixes #55**: Add explicit parentheses to RecordingControlsView condition for clarity
- **Fixes #56**: Use local timezone for recording filenames instead of UTC (better Finder UX)

## Testing Notes
All changes maintain existing code structure per the critical rules:
- ✅ No type renames
- ✅ No Logger removal
- ✅ No view inlining
- ✅ No hardcoded sample rates
- ✅ All doc comments preserved/enhanced

Ready for review and merge.