### PR TITLE
fix: Review round 3 - critical bugs and enhancements

### DIFF
--- a/EchoNotes/Audio/SystemAudioCapture.swift
+++ b/EchoNotes/Audio/SystemAudioCapture.swift
@@ -53,14 +53,19 @@ final class SystemAudioCapture: NSObject, @unchecked Sendable {
         // Try to start with 2x2, fallback to 16x16 if it fails
         do {
             try await stream.startCapture()
+            self.stream = stream
         } catch {
             logger.warning("Failed to start capture with 2x2 config, retrying with 16x16: \(error.localizedDescription)")
             config.width = 16
             config.height = 16
-            try await stream.startCapture()
+            
+            // Create a NEW stream with updated config (old stream may be in bad state)
+            let fallbackStream = SCStream(filter: filter, configuration: config, delegate: self)
+            try fallbackStream.addStreamOutput(self, type: .audio, sampleHandlerQueue: .global(qos: .userInteractive))
+            try await fallbackStream.startCapture()
+            self.stream = fallbackStream
         }
 
-        self.stream = stream
         _isCapturing.withLock { $0 = true }
     }
 

--- a/EchoNotes/Models/Transcript.swift
+++ b/EchoNotes/Models/Transcript.swift
@@ -39,16 +39,30 @@ struct Transcript: Codable, Sendable {
     }
 
     /// Save `.txt` and `.json` files alongside the recording.
+    /// Uses atomic writes to prevent orphaned files on partial failure.
     func save() throws {
         let basePath = recordingURL.deletingPathExtension()
-
-        // Plain text
         let txtURL = basePath.appendingPathExtension("txt")
-        try toPlainText().write(to: txtURL, atomically: true, encoding: .utf8)
-
-        // JSON
         let jsonURL = basePath.appendingPathExtension("json")
-        try toJSON().write(to: jsonURL, options: .atomic)
+        
+        // Write JSON first (more likely to fail due to encoding issues)
+        do {
+            try toJSON().write(to: jsonURL, options: .atomic)
+        } catch {
+            // Clean up and rethrow
+            try? FileManager.default.removeItem(at: jsonURL)
+            throw error
+        }
+        
+        // Write plain text
+        do {
+            try toPlainText().write(to: txtURL, atomically: true, encoding: .utf8)
+        } catch {
+            // Clean up both files on failure
+            try? FileManager.default.removeItem(at: jsonURL)
+            try? FileManager.default.removeItem(at: txtURL)
+            throw error
+        }
     }
 
     /// Format seconds as `MM:SS` or `H:MM:SS` for display.

--- a/EchoNotes/Transcription/ModelManager.swift
+++ b/EchoNotes/Transcription/ModelManager.swift
@@ -86,11 +86,19 @@ final class ModelManager: ObservableObject {
         let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         let modelDir = cacheDir.appendingPathComponent("huggingface/models/argmaxinc/whisperkit-coreml")
         
-        progressMonitorTask = Task { @MainActor in
+        progressMonitorTask = Task {
             while !Task.isCancelled {
-                let currentSize = directorySize(at: modelDir)
+                // Run disk I/O on background thread
+                let currentSize = await Task.detached {
+                    self.directorySize(at: modelDir)
+                }.value
+                
                 let progress = min(0.99, Double(currentSize) / Double(expectedBytes))
-                self.downloadProgress = progress
+                
+                // Only hop to MainActor to update @Published property
+                await MainActor.run {
+                    self.downloadProgress = progress
+                }
                 
                 try? await Task.sleep(nanoseconds: 500_000_000) // 500ms
             }

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -30,12 +30,6 @@ final class TranscriptionManager: ObservableObject {
     /// The model to use for transcription.
     var selectedModel: WhisperModel = .base
 
-    /// Whether the model is currently being downloaded.
-    var isDownloadingModel: Bool { modelManager.isDownloading }
-
-    /// Model download progress (0.0–1.0).
-    var downloadProgress: Double { modelManager.downloadProgress }
-
     /// Prepare the streaming transcriber with a loaded engine.
     func prepareForLiveTranscription() async throws {
         let engine = try await modelManager.ensureEngine(for: selectedModel)

--- a/EchoNotes/Views/MenuBarView.swift
+++ b/EchoNotes/Views/MenuBarView.swift
@@ -29,7 +29,7 @@ struct MenuBarView: View {
 
             if recorder.isRecording {
                 recordingView
-            } else if tm.isTranscribing || tm.isDownloadingModel {
+            } else if tm.isTranscribing || tm.modelManager.isDownloading {
                 transcribingView
             } else if let transcript = tm.transcript {
                 TranscriptDisplayView(transcript: transcript, onReset: { tm.reset() })
@@ -111,7 +111,9 @@ struct MenuBarView: View {
                 ScrollViewReader { proxy in
                     ScrollView {
                         VStack(alignment: .leading, spacing: 2) {
-                            ForEach(Array(tm.streamingTranscriber.segments.enumerated()), id: \.offset) { idx, segment in
+                            // Only show the last 50 segments for performance
+                            // Full array is preserved in StreamingTranscriber.segments for final transcript
+                            ForEach(Array(recentSegments.enumerated()), id: \.offset) { idx, segment in
                                 Text(segment.text.trimmingCharacters(in: .whitespaces))
                                     .font(.caption)
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -122,12 +124,23 @@ struct MenuBarView: View {
                     .frame(maxHeight: 120)
                     .onChange(of: tm.streamingTranscriber.segments.count) { _, newCount in
                         if newCount > 0 {
-                            proxy.scrollTo(newCount - 1, anchor: .bottom)
+                            proxy.scrollTo(min(recentSegments.count - 1, 49), anchor: .bottom)
                         }
                     }
                 }
             }
         }
+    }
+    
+    /// Returns the last 50 segments for live display to avoid SwiftUI performance issues
+    /// with long recordings. Full array is preserved for the final transcript.
+    private var recentSegments: [TranscriptSegment] {
+        let segments = tm.streamingTranscriber.segments
+        let maxVisible = 50
+        if segments.count > maxVisible {
+            return Array(segments.suffix(maxVisible))
+        }
+        return segments
     }
 
     private var idleView: some View {
@@ -195,12 +208,12 @@ struct MenuBarView: View {
 
     private var transcribingView: some View {
         VStack(spacing: 12) {
-            if tm.isDownloadingModel {
+            if tm.modelManager.isDownloading {
                 Text("Downloading model…")
                     .font(.title3)
-                ProgressView(value: tm.downloadProgress)
+                ProgressView(value: tm.modelManager.downloadProgress)
                     .progressViewStyle(.linear)
-                Text("\(Int(tm.downloadProgress * 100))%")
+                Text("\(Int(tm.modelManager.downloadProgress * 100))%")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } else {


### PR DESCRIPTION
## Summary
This PR addresses 5 critical issues from code review round 3:

- 🔴 2 critical bugs
- 🟡 3 enhancements

All changes follow the CRITICAL RULES:
- ✅ No type renames
- ✅ Logger usage preserved
- ✅ Extracted views not inlined
- ✅ AudioConfig.sampleRate references unchanged
- ✅ Doc comments preserved/updated

## Issues Fixed

### 🔴 Bug: SystemAudioCapture fallback reuses same SCStream (Fixes #58)
**Problem:** After failed 2x2 config, catch block retried `startCapture()` on same stream object which may be in bad state.

**Fix:** Create NEW `SCStream` with updated 16x16 config in fallback path.

**Impact:** Prevents persistent failures when initial stream configuration fails.

---

### 🔴 Bug: ModelManager.monitorDownloadProgress runs disk I/O on MainActor (Fixes #59)
**Problem:** `directorySize` does recursive file enumeration on main thread every 500ms during downloads.

**Fix:** Run `directorySize` on detached background Task, only hop to MainActor to update `downloadProgress`.

**Impact:** Eliminates UI freezes during model downloads.

---

### 🟡 Enhancement: Long recordings performance - unbounded segments array (Fixes #60)
**Problem:** `ForEach` with `.enumerated()` diffs entire array on every new segment. For 2hr+ meetings (~1,440 segments) this gets sluggish.

**Fix:** Only show last 50 segments in live view via computed property. Full array preserved in `StreamingTranscriber.segments` for final transcript.

**Impact:** Smooth UI during long recording sessions without data loss.

---

### 🟡 Enhancement: Transcript.save() partial failure leaves orphaned files (Fixes #61)
**Problem:** If `.txt` writes fine but `.json` fails, orphaned `.txt` file remains.

**Fix:** Write JSON first (more likely to fail), then txt. Clean up both files if either operation fails.

**Impact:** Atomic save operations, no orphaned files.

---

### 🟡 Enhancement: Remove unnecessary wrapper properties (Fixes #62)
**Problem:** `TranscriptionManager.isDownloadingModel` and `downloadProgress` are just pass-through computed properties to `modelManager`.

**Fix:** Removed wrappers. `MenuBarView` now accesses `tm.modelManager.isDownloading` and `tm.modelManager.downloadProgress` directly.

**Impact:** Simplified codebase with fewer layers of indirection.

---

## Testing
- ✅ Build successful (`swift build`)
- ✅ All warnings pre-existing (not introduced by changes)

## Files Changed
- `EchoNotes/Audio/SystemAudioCapture.swift`
- `EchoNotes/Models/Transcript.swift`
- `EchoNotes/Transcription/ModelManager.swift`
- `EchoNotes/Transcription/TranscriptionManager.swift`
- `EchoNotes/Views/MenuBarView.swift`