### PR TITLE
Fix final review issues (#69-#76)

### DIFF
--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -75,6 +75,18 @@ final class RecordingEngine: ObservableObject {
             return
         }
 
+        // Check available disk space before recording
+        do {
+            let attrs = try FileManager.default.attributesOfFileSystem(forPath: saveDirectory.path)
+            if let freeSpace = attrs[.systemFreeSize] as? Int64, freeSpace < 500 * 1024 * 1024 {
+                let freeMB = freeSpace / (1024 * 1024)
+                errorMessage = "Low disk space (\(freeMB) MB free). At least 500 MB recommended for recording."
+                return
+            }
+        } catch {
+            logger.warning("Could not check disk space: \(error.localizedDescription)")
+        }
+
         // Create output file with local timezone timestamp
         let timestamp = Self.recordingTimestampFormatter.string(from: Date())
         let filename = "recording-\(timestamp).m4a"

--- a/EchoNotes/Audio/AudioFileWriter.swift
+++ b/EchoNotes/Audio/AudioFileWriter.swift
@@ -46,6 +46,9 @@ final class AudioFileWriter: @unchecked Sendable {
     private var micOffset: Int = 0
     private var writeError: Error?
 
+    /// Tracks in-flight write callbacks so finalize() can wait for them to complete.
+    private let inflightGroup = DispatchGroup()
+
     init(outputURL: URL, sampleRate: Double = AudioConfig.sampleRate, channels: UInt32 = 2, onError: (@Sendable (Error) -> Void)? = nil) throws {
         self.outputURL = outputURL
         self.sampleRate = sampleRate
@@ -69,6 +72,8 @@ final class AudioFileWriter: @unchecked Sendable {
     }
 
     func writeSystemBuffer(_ buffer: SourcedAudioBuffer) {
+        inflightGroup.enter()
+        defer { inflightGroup.leave() }
         lock.lock()
         guard writeError == nil else { lock.unlock(); return }
         systemSamples.append(contentsOf: buffer.samples)
@@ -77,6 +82,8 @@ final class AudioFileWriter: @unchecked Sendable {
     }
 
     func writeMicBuffer(_ buffer: SourcedAudioBuffer) {
+        inflightGroup.enter()
+        defer { inflightGroup.leave() }
         lock.lock()
         guard writeError == nil else { lock.unlock(); return }
         micSamples.append(contentsOf: buffer.samples)
@@ -146,6 +153,8 @@ final class AudioFileWriter: @unchecked Sendable {
     /// synchronization at the capture layer to ensure all callbacks have finished before
     /// finalize is invoked.
     func finalize() {
+        // Wait for all in-flight write callbacks to complete before finalizing.
+        inflightGroup.wait()
         lock.lock()
         guard writeError == nil else { lock.unlock(); return }
         // Pad the shorter stream with silence

--- a/EchoNotes/Audio/MicrophoneCapture.swift
+++ b/EchoNotes/Audio/MicrophoneCapture.swift
@@ -43,11 +43,18 @@ final class MicrophoneCapture: @unchecked Sendable {
             queue: .main
         ) { [weak self] _ in
             guard let self else { return }
-            // Check if engine stopped unexpectedly
-            if !self.engine.isRunning && self._isCapturing.withLock({ $0 }) {
+            // Atomically check and update _isCapturing to avoid races with stopCapture()
+            let wasCapturing = self._isCapturing.withLock { current -> Bool in
+                guard current else { return false }
+                if !self.engine.isRunning {
+                    current = false
+                    return true
+                }
+                return false
+            }
+            if wasCapturing {
                 let error = MicrophoneError.deviceDisconnected
                 self.logger.error("Microphone configuration changed, engine stopped: \(error.localizedDescription)")
-                self._isCapturing.withLock { $0 = false }
                 self.onError?(error)
             }
         }

--- a/EchoNotes/Audio/SystemAudioCapture.swift
+++ b/EchoNotes/Audio/SystemAudioCapture.swift
@@ -59,6 +59,9 @@ final class SystemAudioCapture: NSObject, @unchecked Sendable {
             config.width = 16
             config.height = 16
             
+            // Clean up the original stream before creating a new one to avoid leaking the delegate reference
+            try? stream.removeStreamOutput(self, type: .audio)
+            
             // Create a NEW stream with updated config (old stream may be in bad state)
             let fallbackStream = SCStream(filter: filter, configuration: config, delegate: self)
             try fallbackStream.addStreamOutput(self, type: .audio, sampleHandlerQueue: .global(qos: .userInteractive))

--- a/EchoNotes/Models/Transcript.swift
+++ b/EchoNotes/Models/Transcript.swift
@@ -54,12 +54,11 @@ struct Transcript: Codable, Sendable {
             throw error
         }
         
-        // Write plain text
+        // Write plain text — don't delete the already-written JSON if this fails
         do {
             try toPlainText().write(to: txtURL, atomically: true, encoding: .utf8)
         } catch {
-            // Clean up both files on failure
-            try? FileManager.default.removeItem(at: jsonURL)
+            // Only clean up the txt file, preserve the valid JSON
             try? FileManager.default.removeItem(at: txtURL)
             throw error
         }

--- a/EchoNotes/Transcription/StreamingTranscriber.swift
+++ b/EchoNotes/Transcription/StreamingTranscriber.swift
@@ -13,6 +13,10 @@ import Foundation
 @MainActor
 final class StreamingTranscriber: ObservableObject {
     @Published var segments: [TranscriptSegment] = []
+    /// Older segments flushed from live memory to prevent unbounded growth.
+    private(set) var flushedSegments: [TranscriptSegment] = []
+    /// Maximum segments to keep in memory during live mode.
+    private let maxLiveSegments = 500
     @Published var isProcessing = false
     @Published var error: String?
 
@@ -81,6 +85,7 @@ final class StreamingTranscriber: ObservableObject {
         // Clear queued samples — these are intentionally dropped on reset.
         // If you need to preserve in-flight audio, call flush() before reset().
         queuedSamples = []
+        flushedSegments = []
 
         sampleLock.lock()
         incomingSamples = []
@@ -130,6 +135,7 @@ final class StreamingTranscriber: ObservableObject {
                         text: $0.text
                     )
                 })
+                capSegmentsIfNeeded()
             } catch {
                 self.error = "Live transcription error: \(error.localizedDescription)"
             }
@@ -139,6 +145,7 @@ final class StreamingTranscriber: ObservableObject {
             // Drain queued samples with while-loop instead of recursion
             // Use defer to ensure isProcessing is always reset, even on error/break
             while !queuedSamples.isEmpty {
+                guard !Task.isCancelled else { break }
                 let queued = queuedSamples
                 queuedSamples = []
                 
@@ -160,6 +167,7 @@ final class StreamingTranscriber: ObservableObject {
                             text: $0.text
                         )
                     })
+                    capSegmentsIfNeeded()
                 } catch {
                     self.error = "Live transcription error: \(error.localizedDescription)"
                     break
@@ -168,10 +176,20 @@ final class StreamingTranscriber: ObservableObject {
         }
     }
 
-    /// Resample 48kHz → 16kHz mono for Whisper using the reusable converter.
+    /// Flush older segments to `flushedSegments` when live memory exceeds the cap.
+    private func capSegmentsIfNeeded() {
+        if segments.count > maxLiveSegments {
+            let overflow = segments.count - maxLiveSegments
+            flushedSegments.append(contentsOf: segments.prefix(overflow))
+            segments.removeFirst(overflow)
+        }
+    }
+
+    /// Resample 48kHz → 16kHz mono for Whisper using a fresh converter per call.
+    /// A new AVAudioConverter is created each time to avoid state leakage between chunks.
     nonisolated private func resample(_ samples: [Float]) throws -> [Float] {
         guard !samples.isEmpty else { return [] }
-        guard let converter = resampler else {
+        guard let converter = AVAudioConverter(from: srcFormat, to: dstFormat) else {
             throw NSError(domain: "com.echonotes.whisper", code: 1, 
                          userInfo: [NSLocalizedDescriptionKey: "Failed to convert audio format."])
         }


### PR DESCRIPTION
Addresses all remaining issues from final code review.

## Changes

### Bugs Fixed
- **#69** — Added `Task.isCancelled` check at top of queued chunk processing loop in `StreamingTranscriber`
- **#70** — Create fresh `AVAudioConverter` per `resample()` call instead of reusing stale converter state
- **#71** — Added `DispatchGroup` to `AudioFileWriter` so `finalize()` waits for all in-flight write callbacks
- **#72** — `Transcript.save()` no longer deletes valid JSON when `.txt` write fails
- **#73** — Clean up original `SCStream` output before creating fallback stream (prevents delegate leak)
- **#74** — Atomic check-and-update of `_isCapturing` in config change observer for thread safety

### Enhancements
- **#75** — Cap `segments` array at 500 entries in live mode; older segments flushed to `flushedSegments`
- **#76** — Check available disk space (500MB minimum) before starting recording

All 38 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recording now validates available disk space (minimum 500 MB required) before starting.
  * Improved error handling when audio input devices disconnect unexpectedly.
  * Better cleanup and recovery when audio stream configuration fails.
  * Transcription files are now better preserved when save errors occur.
  * Enhanced memory management for extended transcription sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->