### PR TITLE
Fix finalizeLiveTranscription dropping flushed segments

### DIFF
--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -41,7 +41,7 @@ final class TranscriptionManager: ObservableObject {
     func finalizeLiveTranscription(recordingURL: URL) async {
         await streamingTranscriber.flush()
 
-        let segments = streamingTranscriber.segments
+        let segments = streamingTranscriber.flushedSegments + streamingTranscriber.segments
         guard !segments.isEmpty else { return }
 
         let result = Transcript(


### PR DESCRIPTION
Regression from #75 — when live recordings exceed 500 segments, older ones get moved to `flushedSegments`. But `finalizeLiveTranscription()` only read `segments`, silently dropping the flushed ones from the final transcript.

One-line fix: `flushedSegments + segments` for the complete transcript.

38 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription segment handling to ensure all transcription data is properly included in the final transcript, resulting in more complete and accurate transcriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->