### PR TITLE
Add .app bundle support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ DerivedData/
 *.m4a
 *.wav
 AUDIO-ONLY-UPDATE-SUMMARY.md
+*.app

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.echonotes.app</string>
+    <key>CFBundleName</key>
+    <string>EchoNotes</string>
+    <key>CFBundleDisplayName</key>
+    <string>EchoNotes</string>
+    <key>CFBundleExecutable</key>
+    <string>EchoNotes</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>EchoNotes needs microphone access to record your voice.</string>
+    <key>NSScreenCaptureUsageDescription</key>
+    <string>EchoNotes needs Screen Recording permission to capture system audio (audio only — no video is recorded).</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -54,7 +54,15 @@ swift build
 .build/debug/EchoNotes
 ```
 
-### Build a standalone app
+### Build as macOS App
+
+```bash
+./scripts/build-app.sh
+```
+
+This creates `EchoNotes.app` in the project root. Drag it to `/Applications` to install.
+
+### Build a standalone binary
 
 ```bash
 swift build -c release

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+APP_NAME="EchoNotes"
+APP_BUNDLE="$PROJECT_DIR/$APP_NAME.app"
+
+echo "🔨 Building $APP_NAME (release)..."
+cd "$PROJECT_DIR"
+swift build -c release
+
+echo "📦 Creating app bundle..."
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+
+# Copy binary
+cp "$(swift build -c release --show-bin-path)/$APP_NAME" "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+
+# Copy Info.plist
+cp "$PROJECT_DIR/Info.plist" "$APP_BUNDLE/Contents/Resources/"
+cp "$PROJECT_DIR/Info.plist" "$APP_BUNDLE/Contents/"
+
+echo "✅ Built $APP_BUNDLE"
+echo "   Drag to /Applications to install, or run: open $APP_BUNDLE"


### PR DESCRIPTION
Adds the ability to build EchoNotes as a proper macOS .app bundle that can be dragged into /Applications.

## What's new
- **Info.plist** with LSUIElement (menu bar only), microphone and screen recording usage descriptions, bundle ID `com.echonotes.app`, minimum macOS 14.0
- **scripts/build-app.sh** — builds release binary via `swift build -c release` and assembles the .app bundle structure
- Updated **.gitignore** to exclude .app bundles
- Updated **README.md** with build instructions

## Usage
```bash
./scripts/build-app.sh
open EchoNotes.app
```

No Swift source files or Package.swift were modified.