### PR TITLE
Fix Transcribe button not updating UI

### DIFF
--- a/EchoNotes/App/AppDelegate.swift
+++ b/EchoNotes/App/AppDelegate.swift
@@ -45,7 +45,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupPopover() {
         popover = NSPopover()
         popover.behavior = .transient
-        let view = MenuBarView(recorder: recorder, delegate: self)
+        let view = MenuBarView(
+            recorder: recorder,
+            tm: recorder.transcriptionManager,
+            modelManager: recorder.transcriptionManager.modelManager,
+            delegate: self
+        )
         popover.contentViewController = NSHostingController(rootView: view)
     }
 

--- a/EchoNotes/Views/MenuBarView.swift
+++ b/EchoNotes/Views/MenuBarView.swift
@@ -4,9 +4,9 @@ import SwiftUI
 /// Recording controls, level meters, and transcript display are extracted into separate components.
 struct MenuBarView: View {
     @ObservedObject var recorder: RecordingEngine
+    @ObservedObject var tm: TranscriptionManager
+    @ObservedObject var modelManager: ModelManager
     weak var delegate: AppDelegate?
-
-    private var tm: TranscriptionManager { recorder.transcriptionManager }
 
     var body: some View {
         VStack(spacing: 16) {
@@ -29,7 +29,7 @@ struct MenuBarView: View {
 
             if recorder.isRecording {
                 recordingView
-            } else if tm.isTranscribing || tm.modelManager.isDownloading {
+            } else if tm.isTranscribing || modelManager.isDownloading {
                 transcribingView
             } else if let transcript = tm.transcript {
                 TranscriptDisplayView(transcript: transcript, onReset: { tm.reset() })
@@ -40,7 +40,7 @@ struct MenuBarView: View {
             }
 
             // Error messages
-            if let error = recorder.errorMessage ?? tm.error ?? tm.modelManager.error {
+            if let error = recorder.errorMessage ?? tm.error ?? modelManager.error {
                 Text(error)
                     .font(.caption)
                     .foregroundStyle(.red)
@@ -211,12 +211,12 @@ struct MenuBarView: View {
 
     private var transcribingView: some View {
         VStack(spacing: 12) {
-            if tm.modelManager.isDownloading {
+            if modelManager.isDownloading {
                 Text("Downloading model…")
                     .font(.title3)
-                ProgressView(value: tm.modelManager.downloadProgress)
+                ProgressView(value: modelManager.downloadProgress)
                     .progressViewStyle(.linear)
-                Text("\(Int(tm.modelManager.downloadProgress * 100))%")
+                Text("\(Int(modelManager.downloadProgress * 100))%")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } else {


### PR DESCRIPTION
## The Bug
Tapping Transcribe did nothing visually — UI stayed on 'Recording saved' even though transcription was running in the background (confirmed via logs).

## Root Cause
Classic SwiftUI nested ObservableObject problem. `MenuBarView` only had `@ObservedObject var recorder: RecordingEngine`. The `TranscriptionManager` and `ModelManager` were accessed via a computed property (`recorder.transcriptionManager`), so SwiftUI never subscribed to their `@Published` changes.

## Fix
Pass `TranscriptionManager` and `ModelManager` as explicit `@ObservedObject` bindings so SwiftUI observes them directly.

## Testing
- Build: ✅
- Tests: ✅ 38/38 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WhisperKit CoreML model download script with progress tracking and automatic verification.

* **Improvements**
  * Changed model storage location to documents directory for better persistence and accessibility.
  * Enhanced error message UI styling with improved padding and visibility.
  * Added comprehensive system logging for better diagnostics and troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->