### PR TITLE
Debug incomplete transcriptions — add WhisperEngine logging

### DIFF
--- a/EchoNotes/Transcription/WhisperEngine.swift
+++ b/EchoNotes/Transcription/WhisperEngine.swift
@@ -1,8 +1,10 @@
 import Foundation
 import WhisperKit
+import os
 
 /// Wraps WhisperKit for on-device speech-to-text.
 final class WhisperEngine: @unchecked Sendable {
+    private let logger = Logger(subsystem: "com.echonotes", category: "WhisperEngine")
     private let whisperKit: WhisperKit
 
     init(whisperKit: WhisperKit) {
@@ -14,11 +16,12 @@ final class WhisperEngine: @unchecked Sendable {
         audioURL: URL,
         progressCallback: (@Sendable (Double) -> Void)? = nil
     ) async throws -> [TranscriptSegment] {
+        logger.info("Starting transcription of \(audioURL.lastPathComponent)")
         let result = try await whisperKit.transcribe(
             audioPath: audioURL.path,
-            callback: { progress in
-                // Approximate progress from window position vs total audio
+            callback: { [logger] progress in
                 let audioSeconds = progress.timings.inputAudioSeconds
+                logger.debug("Window \(progress.windowId), audio: \(audioSeconds)s")
                 if audioSeconds > 0 {
                     let processed = Double(progress.windowId + 1) * 30.0
                     progressCallback?(min(processed / audioSeconds, 0.99))
@@ -27,6 +30,9 @@ final class WhisperEngine: @unchecked Sendable {
             }
         )
 
+        let totalSegments = result.flatMap { $0.segments }.count
+        logger.info("Transcription complete: \(result.count) results, \(totalSegments) segments")
+        
         progressCallback?(1.0)
         return mapResults(result)
     }


### PR DESCRIPTION
## Issue
WhisperKit only transcribes the first ~17 seconds of a 95-second recording. OpenAI Whisper (CLI) gets the full transcript from the same file.

## This PR
Adds logging to WhisperEngine to capture:
- Each 30s window being processed
- Total audio duration
- Final result/segment counts

## Next Steps
After getting the logs, likely fixes:
- WhisperKit may need explicit `DecodingOptions` to process all windows
- May need to pass `clipTimestamps` or adjust the chunking config
- Could be a known WhisperKit 0.15.0 issue