### PR TITLE
Fix New button returning to wrong screen

### DIFF
--- a/EchoNotes/Views/MenuBarView.swift
+++ b/EchoNotes/Views/MenuBarView.swift
@@ -32,7 +32,10 @@ struct MenuBarView: View {
             } else if tm.isTranscribing || tm.modelManager.isDownloading {
                 transcribingView
             } else if let transcript = tm.transcript {
-                TranscriptDisplayView(transcript: transcript, onReset: { tm.reset() })
+                TranscriptDisplayView(transcript: transcript, onNew: {
+                    tm.reset()
+                    recorder.lastRecordingURL = nil
+                })
             } else if recorder.lastRecordingURL != nil {
                 readyToTranscribeView
             } else {

--- a/EchoNotes/Views/TranscriptDisplayView.swift
+++ b/EchoNotes/Views/TranscriptDisplayView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Displays a completed transcript with copy and open file actions.
 struct TranscriptDisplayView: View {
     let transcript: Transcript
-    let onReset: () -> Void
+    let onNew: () -> Void
     
     var body: some View {
         VStack(spacing: 8) {
@@ -36,7 +36,7 @@ struct TranscriptDisplayView: View {
 
                 Spacer()
 
-                Button(action: onReset) {
+                Button(action: onNew) {
                     Label("New", systemImage: "arrow.counterclockwise")
                         .font(.caption)
                 }


### PR DESCRIPTION
Tapping New after transcription showed 'Recording saved' instead of the home screen. Now properly resets to idle view.