### PR TITLE
Show 'Loading model' instead of fake download progress when cached

### DIFF
--- a/EchoNotes/Transcription/ModelManager.swift
+++ b/EchoNotes/Transcription/ModelManager.swift
@@ -34,6 +34,7 @@ enum WhisperModel: String, CaseIterable, Sendable {
 final class ModelManager: ObservableObject {
     private let logger = Logger(subsystem: "com.echonotes", category: "ModelManager")
     @Published var isDownloading = false
+    @Published var isLoading = false
     @Published var downloadProgress: Double = 0
     @Published var error: String?
 
@@ -47,21 +48,26 @@ final class ModelManager: ObservableObject {
             return WhisperEngine(whisperKit: whisperKit)
         }
 
-        isDownloading = true
-        downloadProgress = 0
         error = nil
+        let needsDownload = !Self.modelLikelyCached()
+        
+        if needsDownload {
+            isDownloading = true
+            downloadProgress = 0
+            monitorDownloadProgress(for: model)
+        } else {
+            isLoading = true
+        }
 
         defer { 
             isDownloading = false
+            isLoading = false
             progressMonitorTask?.cancel()
             progressMonitorTask = nil
         }
 
         do {
-            // Start monitoring download progress
-            monitorDownloadProgress(for: model)
-            
-            logger.info("Initializing WhisperKit with model: \(model.rawValue)")
+            logger.info("Initializing WhisperKit with model: \(model.rawValue) (cached: \(!needsDownload))")
             let config = WhisperKitConfig(model: model.rawValue)
             let kit = try await WhisperKit(config)
             logger.info("WhisperKit initialized successfully")

--- a/EchoNotes/Views/MenuBarView.swift
+++ b/EchoNotes/Views/MenuBarView.swift
@@ -29,7 +29,7 @@ struct MenuBarView: View {
 
             if recorder.isRecording {
                 recordingView
-            } else if tm.isTranscribing || modelManager.isDownloading {
+            } else if tm.isTranscribing || modelManager.isDownloading || modelManager.isLoading {
                 transcribingView
             } else if let transcript = tm.transcript {
                 TranscriptDisplayView(transcript: transcript, onNew: {
@@ -222,6 +222,11 @@ struct MenuBarView: View {
                 Text("\(Int(modelManager.downloadProgress * 100))%")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            } else if modelManager.isLoading {
+                Text("Loading model…")
+                    .font(.title3)
+                ProgressView()
+                    .controlSize(.small)
             } else {
                 Text("Transcribing…")
                     .font(.title3)


### PR DESCRIPTION
When the WhisperKit model is already on disk, the UI was showing 'Downloading model... 93%' which is misleading. Now shows a simple 'Loading model...' spinner for cached models, and only shows the download progress when actually downloading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading indicator displaying "Loading model…" with a progress view when the model is initializing, providing visual feedback during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->