### PR TITLE
Strip WhisperKit tokens from live transcript view

### DIFF
--- a/EchoNotes/Views/MenuBarView.swift
+++ b/EchoNotes/Views/MenuBarView.swift
@@ -120,7 +120,7 @@ struct MenuBarView: View {
                             // Only show the last 50 segments for performance
                             // Full array is preserved in StreamingTranscriber.segments for final transcript
                             ForEach(Array(recentSegments.enumerated()), id: \.offset) { idx, segment in
-                                Text(segment.text.trimmingCharacters(in: .whitespaces))
+                                Text(segment.cleanText)
                                     .font(.caption)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .id(idx)


### PR DESCRIPTION
## Summary
- The live transcript display during recording was using raw `segment.text` instead of `segment.cleanText`, causing WhisperKit control tokens (`<|startoftranscript|>`, `<|0.00|>`, `<|endoftext|>`, etc.) to appear in the UI
- Post-recording display and saved `.txt` files already used `cleanText` — this fixes the one remaining spot

## Test plan
- [ ] Start a live transcription recording and verify no `<|...|>` tokens appear in the live transcript view

🤖 Generated with [Claude Code](https://claude.com/claude-code)