### PR TITLE
feat: global hotkey ⌘⇧R to toggle recording

### DIFF
--- a/EchoNotes/App/AppDelegate.swift
+++ b/EchoNotes/App/AppDelegate.swift
@@ -9,12 +9,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var eventMonitor: Any?
 
     let recorder = RecordingEngine()
+    private let hotkeyManager = HotkeyManager()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
         setupStatusItem()
         setupPopover()
         setupEventMonitor()
+
+        // Register global hotkey ⌘⇧R to toggle recording
+        hotkeyManager.register { [weak self] in
+            guard let self else { return }
+            Task {
+                if self.recorder.isRecording {
+                    await self.recorder.stopRecording()
+                } else {
+                    await self.recorder.startRecording()
+                }
+                self.updateStatusIcon(isRecording: self.recorder.isRecording)
+            }
+        }
 
         // Pre-download Whisper model on first launch if not already cached
         Task {
@@ -82,5 +96,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         removeEventMonitor()
+        hotkeyManager.unregister()
     }
 }

--- a/EchoNotes/App/AppDelegate.swift
+++ b/EchoNotes/App/AppDelegate.swift
@@ -10,6 +10,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     let recorder = RecordingEngine()
     private let hotkeyManager = HotkeyManager()
+    private var isTogglingRecording = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
@@ -19,8 +20,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Register global hotkey ⌘⇧R to toggle recording
         hotkeyManager.register { [weak self] in
-            guard let self else { return }
+            guard let self, !self.isTogglingRecording else { return }
+            self.isTogglingRecording = true
             Task {
+                defer { self.isTogglingRecording = false }
                 if self.recorder.isRecording {
                     await self.recorder.stopRecording()
                 } else {

--- a/EchoNotes/App/HotkeyManager.swift
+++ b/EchoNotes/App/HotkeyManager.swift
@@ -1,0 +1,92 @@
+import Carbon
+import AppKit
+import os
+
+/// Manages a global keyboard shortcut (⌘⇧R) to toggle recording.
+/// Uses Carbon's RegisterEventHotKey API — no external dependencies.
+@MainActor
+final class HotkeyManager {
+    private let logger = Logger(subsystem: "com.echonotes", category: "HotkeyManager")
+    private var hotkeyRef: EventHotKeyRef?
+    private var eventHandler: EventHandlerRef?
+    private var onToggle: (() -> Void)?
+
+    /// The shared instance used by the Carbon callback to route events.
+    fileprivate static var shared: HotkeyManager?
+
+    /// Register the global hotkey. Call once at app launch.
+    func register(onToggle: @escaping () -> Void) {
+        self.onToggle = onToggle
+        HotkeyManager.shared = self
+
+        // ⌘⇧R: keycode 15 = 'R', modifiers = cmdKey + shiftKey
+        let hotkeyID = EventHotKeyID(signature: fourCharCode("ECHO"), id: 1)
+        var hotkey: EventHotKeyRef?
+        let status = RegisterEventHotKey(
+            UInt32(kVK_ANSI_R),
+            UInt32(cmdKey | shiftKey),
+            hotkeyID,
+            GetApplicationEventTarget(),
+            0,
+            &hotkey
+        )
+
+        guard status == noErr else {
+            logger.error("Failed to register hotkey: \(status)")
+            return
+        }
+        hotkeyRef = hotkey
+
+        // Install Carbon event handler for hotkey events
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        var handler: EventHandlerRef?
+        InstallEventHandler(
+            GetApplicationEventTarget(),
+            hotkeyCallback,
+            1,
+            &eventType,
+            nil,
+            &handler
+        )
+        eventHandler = handler
+        logger.info("Global hotkey ⌘⇧R registered")
+    }
+
+    /// Unregister the hotkey. Call on app quit.
+    func unregister() {
+        if let hotkeyRef {
+            UnregisterEventHotKey(hotkeyRef)
+            self.hotkeyRef = nil
+        }
+        if let eventHandler {
+            RemoveEventHandler(eventHandler)
+            self.eventHandler = nil
+        }
+        HotkeyManager.shared = nil
+        logger.info("Global hotkey unregistered")
+    }
+
+    fileprivate func handleHotkeyPress() {
+        onToggle?()
+    }
+
+    private func fourCharCode(_ string: String) -> FourCharCode {
+        var result: FourCharCode = 0
+        for char in string.utf8.prefix(4) {
+            result = (result << 8) + FourCharCode(char)
+        }
+        return result
+    }
+}
+
+/// Carbon callback — must be a free function. Routes to the shared HotkeyManager.
+private func hotkeyCallback(
+    _ nextHandler: EventHandlerCallRef?,
+    _ event: EventRef?,
+    _ userData: UnsafeMutableRawPointer?
+) -> OSStatus {
+    Task { @MainActor in
+        HotkeyManager.shared?.handleHotkeyPress()
+    }
+    return noErr
+}

--- a/EchoNotes/App/HotkeyManager.swift
+++ b/EchoNotes/App/HotkeyManager.swift
@@ -14,8 +14,18 @@ final class HotkeyManager {
     /// The shared instance used by the Carbon callback to route events.
     fileprivate static var shared: HotkeyManager?
 
+    deinit {
+        // Safety net — ensure cleanup even if unregister() wasn't called explicitly
+        if hotkeyRef != nil || eventHandler != nil {
+            unregister()
+        }
+    }
+
     /// Register the global hotkey. Call once at app launch.
     func register(onToggle: @escaping () -> Void) {
+        if HotkeyManager.shared != nil {
+            logger.warning("Overwriting existing HotkeyManager.shared — was unregister() missed?")
+        }
         self.onToggle = onToggle
         HotkeyManager.shared = self
 
@@ -70,7 +80,7 @@ final class HotkeyManager {
         onToggle?()
     }
 
-    private func fourCharCode(_ string: String) -> FourCharCode {
+    func fourCharCode(_ string: String) -> FourCharCode {
         var result: FourCharCode = 0
         for char in string.utf8.prefix(4) {
             result = (result << 8) + FourCharCode(char)

--- a/EchoNotes/Views/MenuBarView.swift
+++ b/EchoNotes/Views/MenuBarView.swift
@@ -160,6 +160,9 @@ struct MenuBarView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+            Text("⌘⇧R to start recording")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
 
             // Transcription mode picker
             Picker("Transcription", selection: $recorder.transcriptionModeRaw) {

--- a/EchoNotesTests/HotkeyManagerTests.swift
+++ b/EchoNotesTests/HotkeyManagerTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import EchoNotes
+
+@MainActor
+final class HotkeyManagerTests: XCTestCase {
+
+    func testFourCharCodeProducesExpectedValues() {
+        let manager = HotkeyManager()
+        // "ECHO" → 0x4543484F
+        let result = manager.fourCharCode("ECHO")
+        XCTAssertEqual(result, 0x4543484F, "fourCharCode('ECHO') should be 0x4543484F")
+    }
+
+    func testFourCharCodeTruncatesLongStrings() {
+        let manager = HotkeyManager()
+        let four = manager.fourCharCode("ECHO")
+        let long = manager.fourCharCode("ECHOEXTRA")
+        XCTAssertEqual(four, long, "Only first 4 bytes should matter")
+    }
+
+    func testFourCharCodeHandlesShortStrings() {
+        let manager = HotkeyManager()
+        // "AB" → 0x4142
+        let result = manager.fourCharCode("AB")
+        XCTAssertEqual(result, 0x4142, "fourCharCode('AB') should be 0x4142")
+    }
+
+    func testFourCharCodeEmptyString() {
+        let manager = HotkeyManager()
+        let result = manager.fourCharCode("")
+        XCTAssertEqual(result, 0, "fourCharCode('') should be 0")
+    }
+
+    func testRegisterUnregisterLifecycle() {
+        let manager = HotkeyManager()
+        var toggled = false
+        manager.register { toggled = true }
+        // Should not crash
+        manager.unregister()
+        XCTAssertFalse(toggled, "Callback should not fire from register/unregister alone")
+    }
+
+    func testDoubleUnregisterDoesNotCrash() {
+        let manager = HotkeyManager()
+        manager.register { }
+        manager.unregister()
+        manager.unregister() // Should not crash
+    }
+}


### PR DESCRIPTION
Closes #92

## Changes
- **HotkeyManager.swift** — registers global ⌘⇧R hotkey via Carbon's `RegisterEventHotKey` API
- **AppDelegate** — wires hotkey to toggle recording on/off, updates status icon
- **MenuBarView** — shows '⌘⇧R to start recording' hint in idle state

## Details
- Zero external dependencies — uses only Carbon/AppKit frameworks
- Hotkey unregistered on app quit
- Structured for easy future configurability (key combo is isolated in register())
- Works even when popover is closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global shortcut (Cmd+Shift+R) to toggle recording from anywhere.
  * Shortcut hint displayed in the menu bar for discoverability.

* **Bug Fixes**
  * Improved toggle reliability and clean startup/shutdown of the global shortcut to avoid unexpected behavior.

* **Tests**
  * Added unit tests covering the hotkey manager’s behavior and lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->