### PR TITLE
feat: speaker diarization — separate system/mic channels

### DIFF
--- a/EchoNotes/Models/Speaker.swift
+++ b/EchoNotes/Models/Speaker.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Speaker labels for diarized transcripts.
+enum Speaker: String, Codable, Sendable {
+    case user = "You"
+    case remote = "Them"
+
+    /// Display color for speaker labels in the UI.
+    var color: Color {
+        switch self {
+        case .user: .blue
+        case .remote: .green
+        }
+    }
+
+    /// SF Symbol for speaker legend.
+    var icon: String {
+        switch self {
+        case .user: "person.fill"
+        case .remote: "person.2.fill"
+        }
+    }
+}

--- a/EchoNotes/Models/Transcript.swift
+++ b/EchoNotes/Models/Transcript.swift
@@ -5,6 +5,15 @@ struct TranscriptSegment: Codable, Sendable, Equatable {
     let startTime: TimeInterval
     let endTime: TimeInterval
     let text: String
+    /// Speaker label for diarization (e.g. "You", "Them"). Nil for non-diarized transcripts.
+    let speaker: String?
+
+    init(startTime: TimeInterval, endTime: TimeInterval, text: String, speaker: String? = nil) {
+        self.startTime = startTime
+        self.endTime = endTime
+        self.text = text
+        self.speaker = speaker
+    }
 
     /// Text with WhisperKit control tokens stripped out.
     var cleanText: String {
@@ -32,10 +41,16 @@ struct Transcript: Codable, Sendable {
     let createdAt: Date
 
     /// Plain text — all segments joined with spaces, control tokens stripped.
+    /// Includes speaker labels if present.
     func toPlainText() -> String {
-        segments.map { $0.cleanText }
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
+        segments.compactMap { segment in
+            let text = segment.cleanText
+            guard !text.isEmpty else { return nil }
+            if let speaker = segment.speaker {
+                return "\(speaker): \(text)"
+            }
+            return text
+        }.joined(separator: "\n")
     }
 
     /// Timestamped text with `[MM:SS - MM:SS]` prefixes per segment.
@@ -45,7 +60,8 @@ struct Transcript: Codable, Sendable {
             guard !text.isEmpty else { return nil }
             let start = Self.formatTimestamp(segment.startTime)
             let end = Self.formatTimestamp(segment.endTime)
-            return "[\(start) - \(end)] \(text)"
+            let prefix = segment.speaker.map { "\($0): " } ?? ""
+            return "[\(start) - \(end)] \(prefix)\(text)"
         }.joined(separator: "\n")
     }
 

--- a/EchoNotes/Transcription/StreamingTranscriber.swift
+++ b/EchoNotes/Transcription/StreamingTranscriber.swift
@@ -126,13 +126,14 @@ final class StreamingTranscriber: ObservableObject {
             do {
                 let resampled = try resample(chunk)
                 guard let engine = whisperEngine else { return }
-                let newSegments = try await engine.transcribeSamples(resampled)
+                let newSegments = try await engine.transcribeSamples(resampled, speaker: "Them")
 
                 segments.append(contentsOf: newSegments.map {
                     TranscriptSegment(
                         startTime: $0.startTime + timeOffset,
                         endTime: $0.endTime + timeOffset,
-                        text: $0.text
+                        text: $0.text,
+                        speaker: $0.speaker
                     )
                 })
                 capSegmentsIfNeeded()
@@ -158,13 +159,14 @@ final class StreamingTranscriber: ObservableObject {
                 do {
                     let resampled = try resample(queued)
                     guard let engine = whisperEngine else { break }
-                    let newSegments = try await engine.transcribeSamples(resampled)
+                    let newSegments = try await engine.transcribeSamples(resampled, speaker: "Them")
 
                     segments.append(contentsOf: newSegments.map {
                         TranscriptSegment(
                             startTime: $0.startTime + queuedTimeOffset,
                             endTime: $0.endTime + queuedTimeOffset,
-                            text: $0.text
+                            text: $0.text,
+                            speaker: $0.speaker
                         )
                     })
                     capSegmentsIfNeeded()

--- a/EchoNotes/Transcription/StreamingTranscriber.swift
+++ b/EchoNotes/Transcription/StreamingTranscriber.swift
@@ -126,7 +126,7 @@ final class StreamingTranscriber: ObservableObject {
             do {
                 let resampled = try resample(chunk)
                 guard let engine = whisperEngine else { return }
-                let newSegments = try await engine.transcribeSamples(resampled, speaker: "Them")
+                let newSegments = try await engine.transcribeSamples(resampled, speaker: Speaker.remote.rawValue)
 
                 segments.append(contentsOf: newSegments.map {
                     TranscriptSegment(
@@ -159,7 +159,7 @@ final class StreamingTranscriber: ObservableObject {
                 do {
                     let resampled = try resample(queued)
                     guard let engine = whisperEngine else { break }
-                    let newSegments = try await engine.transcribeSamples(resampled, speaker: "Them")
+                    let newSegments = try await engine.transcribeSamples(resampled, speaker: Speaker.remote.rawValue)
 
                     segments.append(contentsOf: newSegments.map {
                         TranscriptSegment(

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -86,7 +86,7 @@ final class TranscriptionManager: ObservableObject {
 
                 try Task.checkCancellation()
 
-                let segments = try await engine.transcribe(audioURL: audioURL) { [weak self] progress in
+                let segments = try await engine.transcribeDiarized(audioURL: audioURL) { [weak self] progress in
                     Task { @MainActor in
                         self?.progress = progress
                     }

--- a/EchoNotes/Transcription/WhisperEngine.swift
+++ b/EchoNotes/Transcription/WhisperEngine.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WhisperKit
+@preconcurrency import AVFoundation
 import os
 
 /// Wraps WhisperKit for on-device speech-to-text.
@@ -38,17 +39,118 @@ final class WhisperEngine: @unchecked Sendable {
     }
 
     /// Transcribe raw 16kHz mono Float32 PCM samples.
-    func transcribeSamples(_ samples: [Float]) async throws -> [TranscriptSegment] {
+    func transcribeSamples(_ samples: [Float], speaker: String? = nil) async throws -> [TranscriptSegment] {
         let result = try await whisperKit.transcribe(audioArray: samples)
-        return mapResults(result)
+        return mapResults(result, speaker: speaker)
     }
 
-    private func mapResults(_ results: [TranscriptionResult]) -> [TranscriptSegment] {
+    /// Transcribe a stereo file with speaker diarization.
+    /// Left channel = system audio ("Them"), right channel = mic ("You").
+    /// Transcribes each channel independently and merges chronologically.
+    func transcribeDiarized(
+        audioURL: URL,
+        progressCallback: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> [TranscriptSegment] {
+        logger.info("Starting diarized transcription of \(audioURL.lastPathComponent)")
+
+        let (systemSamples, micSamples) = try Self.splitChannels(url: audioURL)
+        logger.info("Split channels: system=\(systemSamples.count) mic=\(micSamples.count) samples")
+
+        // Transcribe system audio (left channel = "Them") — 0-50% progress
+        let systemSegments: [TranscriptSegment]
+        if systemSamples.contains(where: { abs($0) > 0.001 }) {
+            systemSegments = try await transcribeSamples(systemSamples, speaker: "Them")
+        } else {
+            systemSegments = []
+        }
+        progressCallback?(0.5)
+
+        // Transcribe mic audio (right channel = "You") — 50-100% progress
+        let micSegments: [TranscriptSegment]
+        if micSamples.contains(where: { abs($0) > 0.001 }) {
+            micSegments = try await transcribeSamples(micSamples, speaker: "You")
+        } else {
+            micSegments = []
+        }
+        progressCallback?(1.0)
+
+        // Merge chronologically
+        let merged = (systemSegments + micSegments).sorted { $0.startTime < $1.startTime }
+        logger.info("Diarized transcription complete: \(merged.count) segments")
+        return merged
+    }
+
+    /// Split a stereo audio file into two mono Float32 arrays at 16kHz.
+    /// Returns (leftChannel, rightChannel).
+    nonisolated static func splitChannels(url: URL) throws -> ([Float], [Float]) {
+        let file = try AVAudioFile(forReading: url)
+        let format = file.processingFormat
+        let frameCount = AVAudioFrameCount(file.length)
+
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            throw NSError(domain: "com.echonotes.whisper", code: 2,
+                         userInfo: [NSLocalizedDescriptionKey: "Failed to create audio buffer"])
+        }
+        try file.read(into: buffer)
+
+        let channelCount = Int(format.channelCount)
+        guard channelCount >= 2, let channelData = buffer.floatChannelData else {
+            throw NSError(domain: "com.echonotes.whisper", code: 3,
+                         userInfo: [NSLocalizedDescriptionKey: "Audio file is not stereo"])
+        }
+
+        let count = Int(buffer.frameLength)
+        let left = Array(UnsafeBufferPointer(start: channelData[0], count: count))
+        let right = Array(UnsafeBufferPointer(start: channelData[1], count: count))
+
+        // Resample to 16kHz if needed
+        let srcRate = format.sampleRate
+        if abs(srcRate - 16000) < 1 {
+            return (left, right)
+        }
+
+        let leftResampled = try resampleMono(left, from: srcRate, to: 16000)
+        let rightResampled = try resampleMono(right, from: srcRate, to: 16000)
+        return (leftResampled, rightResampled)
+    }
+
+    /// Resample mono Float32 samples between sample rates.
+    nonisolated private static func resampleMono(_ samples: [Float], from srcRate: Double, to dstRate: Double) throws -> [Float] {
+        guard !samples.isEmpty else { return [] }
+        let srcFmt = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: srcRate, channels: 1, interleaved: false)!
+        let dstFmt = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: dstRate, channels: 1, interleaved: false)!
+        guard let converter = AVAudioConverter(from: srcFmt, to: dstFmt) else {
+            throw NSError(domain: "com.echonotes.whisper", code: 4,
+                         userInfo: [NSLocalizedDescriptionKey: "Failed to create resampler"])
+        }
+
+        let inBuf = AVAudioPCMBuffer(pcmFormat: srcFmt, frameCapacity: AVAudioFrameCount(samples.count))!
+        inBuf.frameLength = AVAudioFrameCount(samples.count)
+        samples.withUnsafeBufferPointer { ptr in
+            inBuf.floatChannelData![0].update(from: ptr.baseAddress!, count: samples.count)
+        }
+
+        let outFrames = AVAudioFrameCount(Double(samples.count) * dstRate / srcRate) + 256
+        let outBuf = AVAudioPCMBuffer(pcmFormat: dstFmt, frameCapacity: outFrames)!
+
+        var fed = false
+        var err: NSError?
+        converter.convert(to: outBuf, error: &err) { _, status in
+            if !fed { fed = true; status.pointee = .haveData; return inBuf }
+            status.pointee = .noDataNow; return nil
+        }
+        if let err { throw err }
+
+        return Array(UnsafeBufferPointer(start: outBuf.floatChannelData![0], count: Int(outBuf.frameLength)))
+    }
+
+    private func mapResults(_ results: [TranscriptionResult], speaker: String? = nil) -> [TranscriptSegment] {
         results.flatMap { $0.segments.map { segment in
             TranscriptSegment(
                 startTime: Double(segment.start),
                 endTime: Double(segment.end),
-                text: segment.text
+                text: segment.text,
+                speaker: speaker
             )
         }}
     }

--- a/EchoNotes/Transcription/WhisperEngine.swift
+++ b/EchoNotes/Transcription/WhisperEngine.swift
@@ -44,31 +44,41 @@ final class WhisperEngine: @unchecked Sendable {
         return mapResults(result, speaker: speaker)
     }
 
+    /// Minimum RMS amplitude to consider a channel non-silent.
+    /// Below this threshold, the channel is treated as empty (no speech).
+    static let silenceThreshold: Float = 0.001
+
     /// Transcribe a stereo file with speaker diarization.
-    /// Left channel = system audio ("Them"), right channel = mic ("You").
-    /// Transcribes each channel independently and merges chronologically.
+    /// Left channel = system audio (remote), right channel = mic (user).
+    /// Falls back to non-diarized transcription for mono files.
     func transcribeDiarized(
         audioURL: URL,
         progressCallback: (@Sendable (Double) -> Void)? = nil
     ) async throws -> [TranscriptSegment] {
         logger.info("Starting diarized transcription of \(audioURL.lastPathComponent)")
 
+        // Fall back to standard transcription for mono files
+        guard Self.isStereo(url: audioURL) else {
+            logger.info("Mono file detected — falling back to non-diarized transcription")
+            return try await transcribe(audioURL: audioURL, progressCallback: progressCallback)
+        }
+
         let (systemSamples, micSamples) = try Self.splitChannels(url: audioURL)
         logger.info("Split channels: system=\(systemSamples.count) mic=\(micSamples.count) samples")
 
-        // Transcribe system audio (left channel = "Them") — 0-50% progress
+        // Transcribe system audio (left channel = remote speaker) — 0-50% progress
         let systemSegments: [TranscriptSegment]
-        if systemSamples.contains(where: { abs($0) > 0.001 }) {
-            systemSegments = try await transcribeSamples(systemSamples, speaker: "Them")
+        if systemSamples.contains(where: { abs($0) > Self.silenceThreshold }) {
+            systemSegments = try await transcribeSamples(systemSamples, speaker: Speaker.remote.rawValue)
         } else {
             systemSegments = []
         }
         progressCallback?(0.5)
 
-        // Transcribe mic audio (right channel = "You") — 50-100% progress
+        // Transcribe mic audio (right channel = user) — 50-100% progress
         let micSegments: [TranscriptSegment]
-        if micSamples.contains(where: { abs($0) > 0.001 }) {
-            micSegments = try await transcribeSamples(micSamples, speaker: "You")
+        if micSamples.contains(where: { abs($0) > Self.silenceThreshold }) {
+            micSegments = try await transcribeSamples(micSamples, speaker: Speaker.user.rawValue)
         } else {
             micSegments = []
         }
@@ -78,6 +88,12 @@ final class WhisperEngine: @unchecked Sendable {
         let merged = (systemSegments + micSegments).sorted { $0.startTime < $1.startTime }
         logger.info("Diarized transcription complete: \(merged.count) segments")
         return merged
+    }
+
+    /// Check if an audio file has 2+ channels without reading the full file.
+    nonisolated static func isStereo(url: URL) -> Bool {
+        guard let file = try? AVAudioFile(forReading: url) else { return false }
+        return file.processingFormat.channelCount >= 2
     }
 
     /// Split a stereo audio file into two mono Float32 arrays at 16kHz.

--- a/EchoNotes/Views/MenuBarView.swift
+++ b/EchoNotes/Views/MenuBarView.swift
@@ -120,10 +120,17 @@ struct MenuBarView: View {
                             // Only show the last 50 segments for performance
                             // Full array is preserved in StreamingTranscriber.segments for final transcript
                             ForEach(Array(recentSegments.enumerated()), id: \.offset) { idx, segment in
-                                Text(segment.cleanText)
-                                    .font(.caption)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .id(idx)
+                                HStack(alignment: .top, spacing: 4) {
+                                    if let speaker = segment.speaker {
+                                        Text(speaker)
+                                            .font(.caption2.bold())
+                                            .foregroundStyle(speaker == "You" ? .blue : .green)
+                                    }
+                                    Text(segment.cleanText)
+                                        .font(.caption)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+                                .id(idx)
                             }
                         }
                     }

--- a/EchoNotes/Views/MenuBarView.swift
+++ b/EchoNotes/Views/MenuBarView.swift
@@ -124,7 +124,7 @@ struct MenuBarView: View {
                                     if let speaker = segment.speaker {
                                         Text(speaker)
                                             .font(.caption2.bold())
-                                            .foregroundStyle(speaker == "You" ? .blue : .green)
+                                            .foregroundStyle(Speaker(rawValue: speaker)?.color ?? .primary)
                                     }
                                     Text(segment.cleanText)
                                         .font(.caption)

--- a/EchoNotes/Views/TranscriptDisplayView.swift
+++ b/EchoNotes/Views/TranscriptDisplayView.swift
@@ -27,12 +27,11 @@ struct TranscriptDisplayView: View {
             // Speaker legend
             if hasSpeakers {
                 HStack(spacing: 12) {
-                    Label("You", systemImage: "person.fill")
-                        .font(.caption2)
-                        .foregroundStyle(.blue)
-                    Label("Them", systemImage: "person.2.fill")
-                        .font(.caption2)
-                        .foregroundStyle(.green)
+                    ForEach([Speaker.user, .remote], id: \.rawValue) { speaker in
+                        Label(speaker.rawValue, systemImage: speaker.icon)
+                            .font(.caption2)
+                            .foregroundStyle(speaker.color)
+                    }
                 }
             }
 
@@ -74,7 +73,7 @@ struct TranscriptDisplayView: View {
                         if let speaker = segment.speaker {
                             Text(speaker)
                                 .font(.caption2.bold())
-                                .foregroundStyle(speaker == "You" ? .blue : .green)
+                                .foregroundStyle(Speaker(rawValue: speaker)?.color ?? .primary)
                                 .frame(width: 36, alignment: .trailing)
                         }
                         Text(text)

--- a/EchoNotes/Views/TranscriptDisplayView.swift
+++ b/EchoNotes/Views/TranscriptDisplayView.swift
@@ -5,15 +5,36 @@ struct TranscriptDisplayView: View {
     let transcript: Transcript
     let onNew: () -> Void
     
+    /// Whether this transcript has any speaker labels.
+    private var hasSpeakers: Bool {
+        transcript.segments.contains { $0.speaker != nil }
+    }
+
     var body: some View {
         VStack(spacing: 8) {
             ScrollView {
-                Text(transcript.toPlainText())
-                    .font(.system(.caption))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .textSelection(.enabled)
+                if hasSpeakers {
+                    diarizedTranscriptView
+                } else {
+                    Text(transcript.toPlainText())
+                        .font(.system(.caption))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
             }
             .frame(maxHeight: .infinity)
+
+            // Speaker legend
+            if hasSpeakers {
+                HStack(spacing: 12) {
+                    Label("You", systemImage: "person.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.blue)
+                    Label("Them", systemImage: "person.2.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.green)
+                }
+            }
 
             HStack(spacing: 8) {
                 Button(action: {
@@ -42,5 +63,27 @@ struct TranscriptDisplayView: View {
                 }
             }
         }
+    }
+
+    private var diarizedTranscriptView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(transcript.segments.enumerated()), id: \.offset) { _, segment in
+                let text = segment.cleanText
+                if !text.isEmpty {
+                    HStack(alignment: .top, spacing: 6) {
+                        if let speaker = segment.speaker {
+                            Text(speaker)
+                                .font(.caption2.bold())
+                                .foregroundStyle(speaker == "You" ? .blue : .green)
+                                .frame(width: 36, alignment: .trailing)
+                        }
+                        Text(text)
+                            .font(.system(.caption))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+        }
+        .textSelection(.enabled)
     }
 }

--- a/EchoNotesTests/TranscriptTests.swift
+++ b/EchoNotesTests/TranscriptTests.swift
@@ -113,4 +113,102 @@ struct TranscriptTests {
         #expect(a == b)
         #expect(a != c)
     }
+
+    // MARK: - Diarization Tests
+
+    @Test("Plain text includes speaker labels when present")
+    func plainTextWithSpeakers() {
+        let segments = [
+            TranscriptSegment(startTime: 0, endTime: 10, text: "Hello there", speaker: Speaker.user.rawValue),
+            TranscriptSegment(startTime: 10, endTime: 20, text: "Hi, how are you?", speaker: Speaker.remote.rawValue),
+        ]
+        let transcript = makeTranscript(segments: segments)
+        let text = transcript.toPlainText()
+        #expect(text.contains("You: Hello there"))
+        #expect(text.contains("Them: Hi, how are you?"))
+    }
+
+    @Test("Plain text uses newlines with speaker labels")
+    func plainTextSpeakerSeparator() {
+        let segments = [
+            TranscriptSegment(startTime: 0, endTime: 10, text: "Line one", speaker: "You"),
+            TranscriptSegment(startTime: 10, endTime: 20, text: "Line two", speaker: "Them"),
+        ]
+        let transcript = makeTranscript(segments: segments)
+        let text = transcript.toPlainText()
+        #expect(text == "You: Line one\nThem: Line two")
+    }
+
+    @Test("Plain text without speaker labels still works")
+    func plainTextNoSpeakers() {
+        let segments = [
+            TranscriptSegment(startTime: 0, endTime: 10, text: "Just text"),
+            TranscriptSegment(startTime: 10, endTime: 20, text: "More text"),
+        ]
+        let transcript = makeTranscript(segments: segments)
+        let text = transcript.toPlainText()
+        #expect(text == "Just text\nMore text")
+    }
+
+    @Test("Timestamped text includes speaker prefix")
+    func timestampedTextWithSpeakers() {
+        let segments = [
+            TranscriptSegment(startTime: 0, endTime: 15, text: "Hello", speaker: Speaker.user.rawValue),
+            TranscriptSegment(startTime: 15, endTime: 30, text: "World", speaker: Speaker.remote.rawValue),
+        ]
+        let transcript = makeTranscript(segments: segments)
+        let text = transcript.toTimestampedText()
+        #expect(text.contains("[00:00 - 00:15] You: Hello"))
+        #expect(text.contains("[00:15 - 00:30] Them: World"))
+    }
+
+    @Test("Timestamped text without speakers has no prefix")
+    func timestampedTextNoSpeakers() {
+        let segments = [
+            TranscriptSegment(startTime: 0, endTime: 15, text: "Hello"),
+        ]
+        let transcript = makeTranscript(segments: segments)
+        let text = transcript.toTimestampedText()
+        #expect(text == "[00:00 - 00:15] Hello")
+    }
+
+    @Test("Speaker enum raw values match expected strings")
+    func speakerRawValues() {
+        #expect(Speaker.user.rawValue == "You")
+        #expect(Speaker.remote.rawValue == "Them")
+    }
+
+    @Test("Speaker init from raw value works")
+    func speakerFromRaw() {
+        #expect(Speaker(rawValue: "You") == .user)
+        #expect(Speaker(rawValue: "Them") == .remote)
+        #expect(Speaker(rawValue: "Unknown") == nil)
+    }
+
+    @Test("JSON round-trip preserves speaker labels")
+    func jsonRoundTripWithSpeakers() throws {
+        let segments = [
+            TranscriptSegment(startTime: 0, endTime: 10, text: "Hello", speaker: "You"),
+            TranscriptSegment(startTime: 10, endTime: 20, text: "Hi", speaker: "Them"),
+        ]
+        let transcript = makeTranscript(segments: segments)
+        let json = try transcript.toJSON()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Transcript.self, from: json)
+        #expect(decoded.segments[0].speaker == "You")
+        #expect(decoded.segments[1].speaker == "Them")
+    }
+
+    @Test("Empty segments are filtered from plain text")
+    func emptySegmentsFiltered() {
+        let segments = [
+            TranscriptSegment(startTime: 0, endTime: 5, text: "Hello", speaker: "You"),
+            TranscriptSegment(startTime: 5, endTime: 10, text: "   ", speaker: "Them"),
+            TranscriptSegment(startTime: 10, endTime: 15, text: "World", speaker: "You"),
+        ]
+        let transcript = makeTranscript(segments: segments)
+        let text = transcript.toPlainText()
+        #expect(text == "You: Hello\nYou: World")
+    }
 }


### PR DESCRIPTION
Closes #90

## Changes
- **TranscriptSegment** — added optional `speaker` field
- **WhisperEngine** — new `transcribeDiarized()` method that splits stereo M4A into L/R channels, transcribes each independently, labels 'You' (mic/right) and 'Them' (system/left), merges chronologically
- **TranscriptionManager** — post-recording mode now uses diarized transcription by default
- **StreamingTranscriber** — live segments labeled 'Them' (system audio)
- **TranscriptDisplayView** — color-coded speaker labels (blue=You, green=Them) with legend
- **MenuBarView** — live transcript shows speaker labels
- **Transcript** — `toPlainText()` and `toTimestampedText()` include speaker prefixes; JSON export includes speaker field

## How it works
The app already captures stereo audio (system→left, mic→right). This PR transcribes each channel separately and merges the results with speaker attribution. No ML-based diarization needed — the channel separation gives us speaker identity for free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcripts now include per-segment speaker labels and a speaker legend.
  * Diarized transcription (auto speaker separation) with "You"/"Them" labels and color-coded display.
  * Transcript views conditionally render diarized or plain formats and preserve copy/open behavior.

* **Tests**
  * Added tests for speaker labels, timestamped/plain outputs, JSON round-trip, and edge-case handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->