### PR TITLE
fix: settings UI freezing after saving API key

### DIFF
--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -28,13 +28,13 @@ final class TranscriptionManager: ObservableObject {
 
     private static let apiKeyKeychainKey = "openaiAPIKey"
 
-    /// OpenAI API key — stored in Keychain, not UserDefaults.
-    var openaiAPIKey: String {
-        get { KeychainHelper.load(key: Self.apiKeyKeychainKey) ?? "" }
-        set {
-            objectWillChange.send()
-            KeychainHelper.save(key: Self.apiKeyKeychainKey, value: newValue)
-        }
+    /// OpenAI API key — stored in Keychain, with a @Published shadow for SwiftUI reactivity.
+    @Published private(set) var openaiAPIKey: String = KeychainHelper.load(key: apiKeyKeychainKey) ?? ""
+
+    /// Update the API key in both Keychain and the published shadow property.
+    func setOpenAIAPIKey(_ newValue: String) {
+        KeychainHelper.save(key: Self.apiKeyKeychainKey, value: newValue)
+        openaiAPIKey = newValue
     }
 
     let modelManager = ModelManager()

--- a/EchoNotes/Views/SettingsView.swift
+++ b/EchoNotes/Views/SettingsView.swift
@@ -54,7 +54,7 @@ struct SettingsView: View {
 
                         HStack(spacing: 8) {
                             Button(action: {
-                                tm.openaiAPIKey = apiKeyInput
+                                tm.setOpenAIAPIKey(apiKeyInput)
                             }) {
                                 Text("Save")
                                     .font(.caption)
@@ -65,7 +65,7 @@ struct SettingsView: View {
 
                             if !tm.openaiAPIKey.isEmpty {
                                 Button(action: {
-                                    tm.openaiAPIKey = ""
+                                    tm.setOpenAIAPIKey("")
                                     apiKeyInput = ""
                                 }) {
                                     Text("Remove Key")


### PR DESCRIPTION
The computed property backed by Keychain wasn't giving SwiftUI enough info to re-render. Added a @Published shadow property that stays in sync with the Keychain store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal API key management architecture for better stability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->