### PR TITLE
fix: build error — wrong Transcript init parameters

### DIFF
--- a/EchoNotes/Models/RecordingLibrary.swift
+++ b/EchoNotes/Models/RecordingLibrary.swift
@@ -37,9 +37,9 @@ struct RecordingEntry: Identifiable, Sendable {
             // Create a simple transcript with the full text as one segment
             let segment = TranscriptSegment(startTime: 0, endTime: duration, text: text)
             return Transcript(
-                date: date,
                 segments: [segment],
-                recordingURL: url
+                recordingURL: url,
+                createdAt: date
             )
         }
 


### PR DESCRIPTION
Used `date:` instead of `createdAt:` in the .txt fallback path.