### PR TITLE
feat: multi-provider AI settings + bigger window

### DIFF
--- a/EchoNotes/AI/AIProvider.swift
+++ b/EchoNotes/AI/AIProvider.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Supported AI providers for meeting summarization.
+enum AIProvider: String, CaseIterable, Codable, Sendable, Identifiable {
+    case openai = "OpenAI"
+    case anthropic = "Anthropic"
+    case google = "Google Gemini"
+    case ollama = "Ollama (Local)"
+
+    var id: String { rawValue }
+
+    /// Display name shown in the UI.
+    var displayName: String { rawValue }
+
+    /// Placeholder text for the API key field.
+    var apiKeyPlaceholder: String {
+        switch self {
+        case .openai: return "sk-..."
+        case .anthropic: return "sk-ant-..."
+        case .google: return "AIza..."
+        case .ollama: return "No API key needed"
+        }
+    }
+
+    /// Whether this provider requires an API key.
+    var requiresAPIKey: Bool {
+        self != .ollama
+    }
+
+    /// Default API endpoint.
+    var defaultEndpoint: String {
+        switch self {
+        case .openai: return "https://api.openai.com/v1/chat/completions"
+        case .anthropic: return "https://api.anthropic.com/v1/messages"
+        case .google: return "https://generativelanguage.googleapis.com/v1beta/models"
+        case .ollama: return "http://localhost:11434/v1/chat/completions"
+        }
+    }
+
+    /// Default model for this provider.
+    var defaultModel: String {
+        switch self {
+        case .openai: return "gpt-4o-mini"
+        case .anthropic: return "claude-sonnet-4-5"
+        case .google: return "gemini-2.0-flash"
+        case .ollama: return "llama3.2"
+        }
+    }
+
+    /// Available model options for the provider.
+    var modelOptions: [String] {
+        switch self {
+        case .openai: return ["gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "gpt-4.1"]
+        case .anthropic: return ["claude-sonnet-4-5", "claude-haiku-3-5"]
+        case .google: return ["gemini-2.0-flash", "gemini-2.5-pro"]
+        case .ollama: return ["llama3.2", "llama3.1", "mistral", "gemma2"]
+        }
+    }
+
+    /// How the API key is sent in the request.
+    var authHeaderName: String {
+        switch self {
+        case .anthropic: return "x-api-key"
+        default: return "Authorization"
+        }
+    }
+
+    /// Format the auth header value.
+    func authHeaderValue(apiKey: String) -> String {
+        switch self {
+        case .anthropic: return apiKey
+        default: return "Bearer \(apiKey)"
+        }
+    }
+}

--- a/EchoNotes/AI/AIService.swift
+++ b/EchoNotes/AI/AIService.swift
@@ -36,17 +36,145 @@ final class AIService: Sendable {
         let apiKey: String
         let model: String
         let endpoint: URL
+        let provider: AIProvider
 
-        init(apiKey: String, model: String = "gpt-4o-mini", endpoint: URL = URL(string: "https://api.openai.com/v1/chat/completions")!) {
+        init(apiKey: String, model: String = "gpt-4o-mini", endpoint: URL = URL(string: "https://api.openai.com/v1/chat/completions")!, provider: AIProvider = .openai) {
             self.apiKey = apiKey
             self.model = model
             self.endpoint = endpoint
+            self.provider = provider
         }
     }
 
-    /// Summarize a transcript using OpenAI.
+    /// Summarize a transcript using the configured AI provider.
     func summarize(transcript: String, config: Configuration) async throws -> MeetingSummary {
-        let prompt = """
+        switch config.provider {
+        case .anthropic:
+            return try await summarizeAnthropic(transcript: transcript, config: config)
+        case .google:
+            return try await summarizeGoogle(transcript: transcript, config: config)
+        default:
+            // OpenAI-compatible (OpenAI, Ollama)
+            return try await summarizeOpenAICompatible(transcript: transcript, config: config)
+        }
+    }
+
+    // MARK: - OpenAI-compatible (OpenAI, Ollama)
+
+    private func summarizeOpenAICompatible(transcript: String, config: Configuration) async throws -> MeetingSummary {
+        let prompt = summaryPrompt(transcript: transcript)
+
+        var requestBody: [String: Any] = [
+            "model": config.model,
+            "messages": [
+                ["role": "system", "content": "You are a meeting assistant. Extract structured summaries from transcripts. Respond only with valid JSON."],
+                ["role": "user", "content": prompt]
+            ],
+            "temperature": 0.3,
+            "max_tokens": 2000
+        ]
+
+        // Only add response_format for non-Ollama (some local models don't support it)
+        if config.provider != .ollama {
+            requestBody["response_format"] = ["type": "json_object"]
+        }
+
+        var request = URLRequest(url: config.endpoint)
+        request.httpMethod = "POST"
+        request.setValue(config.provider.authHeaderValue(apiKey: config.apiKey), forHTTPHeaderField: config.provider.authHeaderName)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+        request.timeoutInterval = 120
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AIError.invalidResponse
+        }
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? "unknown"
+            throw AIError.apiError(statusCode: httpResponse.statusCode, message: body)
+        }
+
+        return try parseResponse(data)
+    }
+
+    // MARK: - Anthropic
+
+    private func summarizeAnthropic(transcript: String, config: Configuration) async throws -> MeetingSummary {
+        let prompt = summaryPrompt(transcript: transcript)
+
+        let requestBody: [String: Any] = [
+            "model": config.model,
+            "max_tokens": 2000,
+            "messages": [
+                ["role": "user", "content": prompt]
+            ],
+            "system": "You are a meeting assistant. Extract structured summaries from transcripts. Respond only with valid JSON."
+        ]
+
+        var request = URLRequest(url: config.endpoint)
+        request.httpMethod = "POST"
+        request.setValue(config.apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+        request.timeoutInterval = 120
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AIError.invalidResponse
+        }
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? "unknown"
+            throw AIError.apiError(statusCode: httpResponse.statusCode, message: body)
+        }
+
+        return try parseAnthropicResponse(data)
+    }
+
+    // MARK: - Google Gemini
+
+    private func summarizeGoogle(transcript: String, config: Configuration) async throws -> MeetingSummary {
+        let prompt = summaryPrompt(transcript: transcript)
+
+        let endpointURL = URL(string: "\(config.provider.defaultEndpoint)/\(config.model):generateContent?key=\(config.apiKey)")!
+
+        let requestBody: [String: Any] = [
+            "contents": [
+                ["parts": [["text": "You are a meeting assistant. Extract structured summaries from transcripts. Respond only with valid JSON.\n\n\(prompt)"]]]
+            ],
+            "generationConfig": [
+                "temperature": 0.3,
+                "maxOutputTokens": 2000,
+                "responseMimeType": "application/json"
+            ]
+        ]
+
+        var request = URLRequest(url: endpointURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+        request.timeoutInterval = 120
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AIError.invalidResponse
+        }
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? "unknown"
+            throw AIError.apiError(statusCode: httpResponse.statusCode, message: body)
+        }
+
+        return try parseGoogleResponse(data)
+    }
+
+    // MARK: - Shared Prompt
+
+    private func summaryPrompt(transcript: String) -> String {
+        """
         Analyze this meeting transcript and provide a structured summary.
 
         Respond ONLY with valid JSON in this exact format:
@@ -62,36 +190,6 @@ final class AIService: Sendable {
         TRANSCRIPT:
         \(transcript)
         """
-
-        let requestBody: [String: Any] = [
-            "model": config.model,
-            "messages": [
-                ["role": "system", "content": "You are a meeting assistant. Extract structured summaries from transcripts. Respond only with valid JSON."],
-                ["role": "user", "content": prompt]
-            ],
-            "response_format": ["type": "json_object"],
-            "temperature": 0.3,
-            "max_tokens": 2000
-        ]
-
-        var request = URLRequest(url: config.endpoint)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
-        request.timeoutInterval = 60
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw AIError.invalidResponse
-        }
-        guard httpResponse.statusCode == 200 else {
-            let body = String(data: data, encoding: .utf8) ?? "unknown"
-            throw AIError.apiError(statusCode: httpResponse.statusCode, message: body)
-        }
-
-        return try parseResponse(data)
     }
 
     /// Parse OpenAI chat completion response into MeetingSummary.
@@ -119,6 +217,52 @@ final class AIService: Sendable {
     }
 }
 
+    /// Parse Anthropic messages API response.
+    func parseAnthropicResponse(_ data: Data) throws -> MeetingSummary {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]],
+              let first = content.first,
+              let text = first["text"] as? String else {
+            throw AIError.invalidResponse
+        }
+
+        var cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.hasPrefix("```json") { cleaned = String(cleaned.dropFirst(7)) }
+        if cleaned.hasPrefix("```") { cleaned = String(cleaned.dropFirst(3)) }
+        if cleaned.hasSuffix("```") { cleaned = String(cleaned.dropLast(3)) }
+        cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let summaryData = cleaned.data(using: .utf8) else {
+            throw AIError.invalidResponse
+        }
+        return try JSONDecoder().decode(MeetingSummary.self, from: summaryData)
+    }
+
+    /// Parse Google Gemini generateContent response.
+    func parseGoogleResponse(_ data: Data) throws -> MeetingSummary {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let candidates = json["candidates"] as? [[String: Any]],
+              let first = candidates.first,
+              let content = first["content"] as? [String: Any],
+              let parts = content["parts"] as? [[String: Any]],
+              let firstPart = parts.first,
+              let text = firstPart["text"] as? String else {
+            throw AIError.invalidResponse
+        }
+
+        var cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.hasPrefix("```json") { cleaned = String(cleaned.dropFirst(7)) }
+        if cleaned.hasPrefix("```") { cleaned = String(cleaned.dropFirst(3)) }
+        if cleaned.hasSuffix("```") { cleaned = String(cleaned.dropLast(3)) }
+        cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let summaryData = cleaned.data(using: .utf8) else {
+            throw AIError.invalidResponse
+        }
+        return try JSONDecoder().decode(MeetingSummary.self, from: summaryData)
+    }
+}
+
 enum AIError: LocalizedError {
     case noAPIKey
     case invalidResponse
@@ -126,7 +270,7 @@ enum AIError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .noAPIKey: return "No OpenAI API key configured. Add one in settings."
+        case .noAPIKey: return "No API key configured. Add one in Settings."
         case .invalidResponse: return "Invalid response from AI service."
         case .apiError(let code, let msg): return "API error (\(code)): \(msg)"
         }

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -26,12 +26,49 @@ final class TranscriptionManager: ObservableObject {
     @Published var isSummarizing = false
     @Published var summary: MeetingSummary?
 
-    private static let apiKeyDefaultsKey = "openaiAPIKey"
+    // MARK: - AI Provider Settings
 
-    /// OpenAI API key — stored in UserDefaults, synced via @Published for SwiftUI.
-    /// Note: @AppStorage inside ObservableObject causes re-render loops. Use @Published + manual sync.
+    private static let apiKeyDefaultsKey = "openaiAPIKey"
+    private static let providerDefaultsKey = "aiProvider"
+    private static let aiModelDefaultsKey = "aiModel"
+
+    /// API key for the selected AI provider.
     @Published var openaiAPIKey: String = UserDefaults.standard.string(forKey: apiKeyDefaultsKey) ?? "" {
         didSet { UserDefaults.standard.set(openaiAPIKey, forKey: Self.apiKeyDefaultsKey) }
+    }
+
+    /// Selected AI provider for summarization.
+    @Published var selectedProvider: AIProvider = {
+        if let raw = UserDefaults.standard.string(forKey: providerDefaultsKey),
+           let provider = AIProvider(rawValue: raw) {
+            return provider
+        }
+        return .openai
+    }() {
+        didSet { UserDefaults.standard.set(selectedProvider.rawValue, forKey: Self.providerDefaultsKey) }
+    }
+
+    /// Selected model for AI summarization.
+    @Published var selectedAIModel: String = UserDefaults.standard.string(forKey: aiModelDefaultsKey) ?? AIProvider.openai.defaultModel {
+        didSet { UserDefaults.standard.set(selectedAIModel, forKey: Self.aiModelDefaultsKey) }
+    }
+
+    /// Whether the current provider is configured and ready to use.
+    var isAIConfigured: Bool {
+        if selectedProvider.requiresAPIKey {
+            return !openaiAPIKey.isEmpty
+        }
+        return true // Ollama doesn't need a key
+    }
+
+    /// Build an AIService.Configuration from current settings.
+    func aiConfiguration() -> AIService.Configuration {
+        AIService.Configuration(
+            apiKey: openaiAPIKey,
+            model: selectedAIModel,
+            endpoint: URL(string: selectedProvider.defaultEndpoint)!,
+            provider: selectedProvider
+        )
     }
 
     let modelManager = ModelManager()
@@ -133,10 +170,10 @@ final class TranscriptionManager: ObservableObject {
         await task.value
     }
 
-    /// Summarize the current transcript using OpenAI.
+    /// Summarize the current transcript using the configured AI provider.
     func summarize() async {
         guard let transcript else { return }
-        guard !openaiAPIKey.isEmpty else {
+        guard isAIConfigured else {
             error = AIError.noAPIKey.localizedDescription
             return
         }
@@ -146,7 +183,7 @@ final class TranscriptionManager: ObservableObject {
         summary = nil
 
         do {
-            let config = AIService.Configuration(apiKey: openaiAPIKey)
+            let config = aiConfiguration()
             let service = AIService()
             let result = try await service.summarize(transcript: transcript.toPlainText(), config: config)
 

--- a/EchoNotes/Views/MenuBarView.swift
+++ b/EchoNotes/Views/MenuBarView.swift
@@ -78,7 +78,7 @@ struct MenuBarView: View {
                 TranscriptDisplayView(transcript: transcript, onNew: {
                     tm.reset()
                     recorder.lastRecordingURL = nil
-                }, onSummarize: tm.openaiAPIKey.isEmpty ? nil : {
+                }, onSummarize: !tm.isAIConfigured ? nil : {
                     Task { await tm.summarize() }
                 }, isSummarizing: tm.isSummarizing)
             } else if recorder.lastRecordingURL != nil {
@@ -117,8 +117,8 @@ struct MenuBarView: View {
             }
         }
         .padding()
-        .frame(width: 340)
-        .frame(minHeight: 300, maxHeight: 560)
+        .frame(width: 400)
+        .frame(minHeight: 360, maxHeight: 640)
     }
 
     // MARK: - State Views
@@ -236,7 +236,7 @@ struct MenuBarView: View {
             }
 
             // Hint about AI summaries if key is configured
-            if !tm.openaiAPIKey.isEmpty {
+            if tm.isAIConfigured {
                 HStack(spacing: 4) {
                     Image(systemName: "sparkles")
                         .font(.caption2)

--- a/EchoNotes/Views/RecordingDetailView.swift
+++ b/EchoNotes/Views/RecordingDetailView.swift
@@ -198,7 +198,7 @@ struct RecordingDetailView: View {
                         .buttonStyle(.plain)
                         .foregroundStyle(.secondary)
                         .disabled(isSummarizing)
-                    } else if !tm.openaiAPIKey.isEmpty {
+                    } else if tm.isAIConfigured {
                         // No summary, has API key
                         Button(action: { generateSummary() }) {
                             HStack {
@@ -306,7 +306,7 @@ struct RecordingDetailView: View {
         Task {
             do {
                 let service = AIService()
-                let config = AIService.Configuration(apiKey: tm.openaiAPIKey)
+                let config = tm.aiConfiguration()
                 let text = transcript.toPlainText()
                 let result = try await service.summarize(transcript: text, config: config)
 

--- a/EchoNotes/Views/SettingsView.swift
+++ b/EchoNotes/Views/SettingsView.swift
@@ -1,12 +1,13 @@
 import SwiftUI
 
-/// Settings page for app configuration (AI features, etc).
+/// Settings page for app configuration (AI provider, model, etc).
 struct SettingsView: View {
     @ObservedObject var tm: TranscriptionManager
     let onBack: () -> Void
 
     @State private var apiKeyInput: String = ""
     @State private var showKey = false
+    @State private var saved = false
 
     var body: some View {
         VStack(spacing: 12) {
@@ -24,87 +25,152 @@ struct SettingsView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    // AI Summarization section
-                    VStack(alignment: .leading, spacing: 8) {
-                        Label("AI Summarization", systemImage: "sparkles")
-                            .font(.caption.bold())
-
-                        Text("Add an OpenAI API key to enable AI-powered meeting summaries after transcription.")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-
-                        HStack(spacing: 6) {
-                            Group {
-                                if showKey {
-                                    TextField("sk-...", text: $apiKeyInput)
-                                } else {
-                                    SecureField("sk-...", text: $apiKeyInput)
-                                }
-                            }
-                            .font(.caption)
-                            .textFieldStyle(.roundedBorder)
-
-                            Button(action: { showKey.toggle() }) {
-                                Image(systemName: showKey ? "eye.slash" : "eye")
-                                    .font(.caption2)
-                            }
-                            .buttonStyle(.plain)
-                            .foregroundStyle(.secondary)
-                        }
-
-                        HStack(spacing: 8) {
-                            Button(action: {
-                                tm.openaiAPIKey = apiKeyInput
-                            }) {
-                                Text("Save")
-                                    .font(.caption)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
-                            .disabled(apiKeyInput == tm.openaiAPIKey)
-
-                            if !tm.openaiAPIKey.isEmpty {
-                                Button(action: {
-                                    tm.openaiAPIKey = ""
-                                    apiKeyInput = ""
-                                }) {
-                                    Text("Remove Key")
-                                        .font(.caption)
-                                }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
-                                .tint(.red)
-                            }
-
-                            Spacer()
-
-                            if !tm.openaiAPIKey.isEmpty {
-                                Label("Active", systemImage: "checkmark.circle.fill")
-                                    .font(.caption2)
-                                    .foregroundStyle(.green)
-                            }
-                        }
-                    }
-                    .padding(10)
-                    .background(Color.secondary.opacity(0.05))
-                    .cornerRadius(8)
-
-                    // About section
-                    VStack(alignment: .leading, spacing: 4) {
-                        Label("About", systemImage: "info.circle")
-                            .font(.caption.bold())
-                        Text("EchoNotes — local-first meeting recorder with on-device transcription via WhisperKit.")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(10)
-                    .background(Color.secondary.opacity(0.05))
-                    .cornerRadius(8)
+                    aiProviderSection
+                    aboutSection
                 }
             }
         }
         .onAppear {
             apiKeyInput = tm.openaiAPIKey
         }
+    }
+
+    // MARK: - AI Provider Section
+
+    private var aiProviderSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("AI Summarization", systemImage: "sparkles")
+                .font(.subheadline.bold())
+
+            Text("Choose an AI provider for meeting summaries. Your API key is stored locally and never sent anywhere except the provider's API.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            // Provider picker
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Provider")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+
+                Picker("", selection: $tm.selectedProvider) {
+                    ForEach(AIProvider.allCases) { provider in
+                        Text(provider.displayName).tag(provider)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: tm.selectedProvider) { _, newValue in
+                    tm.selectedAIModel = newValue.defaultModel
+                    // Clear key when switching providers (different key formats)
+                    if newValue.requiresAPIKey && apiKeyInput.isEmpty {
+                        apiKeyInput = ""
+                    }
+                }
+            }
+
+            // Model picker
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Model")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+
+                Picker("", selection: $tm.selectedAIModel) {
+                    ForEach(tm.selectedProvider.modelOptions, id: \.self) { model in
+                        Text(model).tag(model)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+
+            // API Key (if required)
+            if tm.selectedProvider.requiresAPIKey {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("API Key")
+                        .font(.caption.bold())
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 6) {
+                        Group {
+                            if showKey {
+                                TextField(tm.selectedProvider.apiKeyPlaceholder, text: $apiKeyInput)
+                            } else {
+                                SecureField(tm.selectedProvider.apiKeyPlaceholder, text: $apiKeyInput)
+                            }
+                        }
+                        .font(.caption)
+                        .textFieldStyle(.roundedBorder)
+
+                        Button(action: { showKey.toggle() }) {
+                            Image(systemName: showKey ? "eye.slash" : "eye")
+                                .font(.caption2)
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 8) {
+                        Button(action: {
+                            tm.openaiAPIKey = apiKeyInput
+                            saved = true
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { saved = false }
+                        }) {
+                            Text(saved ? "Saved ✓" : "Save")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(apiKeyInput == tm.openaiAPIKey)
+
+                        if !tm.openaiAPIKey.isEmpty {
+                            Button(action: {
+                                tm.openaiAPIKey = ""
+                                apiKeyInput = ""
+                            }) {
+                                Text("Remove Key")
+                                    .font(.caption)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .tint(.red)
+                        }
+
+                        Spacer()
+
+                        if tm.isAIConfigured {
+                            Label("Active", systemImage: "checkmark.circle.fill")
+                                .font(.caption2)
+                                .foregroundStyle(.green)
+                        }
+                    }
+                }
+            } else {
+                // Ollama — no key needed, just check if it's running
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.green)
+                    Text("No API key needed — make sure Ollama is running locally")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(12)
+        .background(Color.secondary.opacity(0.05))
+        .cornerRadius(8)
+    }
+
+    // MARK: - About Section
+
+    private var aboutSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label("About", systemImage: "info.circle")
+                .font(.caption.bold())
+            Text("EchoNotes — local-first meeting recorder with on-device transcription via WhisperKit.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .background(Color.secondary.opacity(0.05))
+        .cornerRadius(8)
     }
 }

--- a/EchoNotesTests/AIProviderTests.swift
+++ b/EchoNotesTests/AIProviderTests.swift
@@ -1,0 +1,146 @@
+import Testing
+import Foundation
+@testable import EchoNotes
+
+@Suite("AIProvider")
+struct AIProviderTests {
+
+    @Test("All providers have a display name")
+    func displayNames() {
+        for provider in AIProvider.allCases {
+            #expect(!provider.displayName.isEmpty)
+        }
+    }
+
+    @Test("All providers have a default model")
+    func defaultModels() {
+        for provider in AIProvider.allCases {
+            #expect(!provider.defaultModel.isEmpty)
+        }
+    }
+
+    @Test("All providers have at least one model option")
+    func modelOptions() {
+        for provider in AIProvider.allCases {
+            #expect(!provider.modelOptions.isEmpty)
+            #expect(provider.modelOptions.contains(provider.defaultModel))
+        }
+    }
+
+    @Test("All providers have a default endpoint")
+    func endpoints() {
+        for provider in AIProvider.allCases {
+            let url = URL(string: provider.defaultEndpoint)
+            #expect(url != nil, "Invalid endpoint URL for \(provider.displayName)")
+        }
+    }
+
+    @Test("Only Ollama doesn't require an API key")
+    func apiKeyRequirements() {
+        #expect(AIProvider.openai.requiresAPIKey)
+        #expect(AIProvider.anthropic.requiresAPIKey)
+        #expect(AIProvider.google.requiresAPIKey)
+        #expect(!AIProvider.ollama.requiresAPIKey)
+    }
+
+    @Test("OpenAI uses Bearer auth")
+    func openaiAuth() {
+        let provider = AIProvider.openai
+        #expect(provider.authHeaderName == "Authorization")
+        #expect(provider.authHeaderValue(apiKey: "test-key") == "Bearer test-key")
+    }
+
+    @Test("Anthropic uses x-api-key header")
+    func anthropicAuth() {
+        let provider = AIProvider.anthropic
+        #expect(provider.authHeaderName == "x-api-key")
+        #expect(provider.authHeaderValue(apiKey: "sk-ant-123") == "sk-ant-123")
+    }
+
+    @Test("Provider raw values are stable for persistence")
+    func rawValues() {
+        #expect(AIProvider.openai.rawValue == "OpenAI")
+        #expect(AIProvider.anthropic.rawValue == "Anthropic")
+        #expect(AIProvider.google.rawValue == "Google Gemini")
+        #expect(AIProvider.ollama.rawValue == "Ollama (Local)")
+    }
+
+    @Test("Provider JSON round-trip")
+    func jsonRoundTrip() throws {
+        for provider in AIProvider.allCases {
+            let encoded = try JSONEncoder().encode(provider)
+            let decoded = try JSONDecoder().decode(AIProvider.self, from: encoded)
+            #expect(decoded == provider)
+        }
+    }
+
+    @Test("AIService.Configuration includes provider")
+    func configWithProvider() {
+        let config = AIService.Configuration(
+            apiKey: "test",
+            model: "claude-sonnet-4-5",
+            endpoint: URL(string: "https://api.anthropic.com/v1/messages")!,
+            provider: .anthropic
+        )
+        #expect(config.provider == .anthropic)
+        #expect(config.model == "claude-sonnet-4-5")
+    }
+
+    // MARK: - Response Parsing
+
+    @Test("parseAnthropicResponse handles valid response")
+    func parseAnthropic() throws {
+        let service = AIService()
+        let json: [String: Any] = [
+            "content": [
+                ["type": "text", "text": """
+                {"summary":"Team sync","actionItems":["Ship it"],"keyDecisions":["Use Swift"],"openQuestions":[]}
+                """]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let result = try service.parseAnthropicResponse(data)
+        #expect(result.summary == "Team sync")
+        #expect(result.actionItems == ["Ship it"])
+    }
+
+    @Test("parseGoogleResponse handles valid response")
+    func parseGoogle() throws {
+        let service = AIService()
+        let json: [String: Any] = [
+            "candidates": [[
+                "content": [
+                    "parts": [
+                        ["text": """
+                        {"summary":"Quick chat","actionItems":[],"keyDecisions":["Go with plan B"],"openQuestions":["Timeline?"]}
+                        """]
+                    ]
+                ]
+            ]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let result = try service.parseGoogleResponse(data)
+        #expect(result.summary == "Quick chat")
+        #expect(result.keyDecisions == ["Go with plan B"])
+    }
+
+    @Test("parseAnthropicResponse throws on empty content")
+    func parseAnthropicEmpty() {
+        let service = AIService()
+        let json: [String: Any] = ["content": []]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        #expect(throws: AIError.self) {
+            try service.parseAnthropicResponse(data)
+        }
+    }
+
+    @Test("parseGoogleResponse throws on empty candidates")
+    func parseGoogleEmpty() {
+        let service = AIService()
+        let json: [String: Any] = ["candidates": []]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        #expect(throws: AIError.self) {
+            try service.parseGoogleResponse(data)
+        }
+    }
+}


### PR DESCRIPTION
## What
Settings now supports 4 AI providers instead of just OpenAI. Window bumped from 340×560 to 400×640.

## Providers
- **OpenAI** — gpt-4o-mini, gpt-4o, gpt-4.1-mini, gpt-4.1
- **Anthropic** — claude-sonnet-4-5, claude-haiku-3-5
- **Google Gemini** — gemini-2.0-flash, gemini-2.5-pro
- **Ollama (Local)** — llama3.2, llama3.1, mistral, gemma2 (no API key needed)

## Settings UI
- Segmented provider picker
- Model dropdown per provider
- API key field adapts placeholder per provider
- Ollama shows 'no key needed' message
- 'Saved ✓' confirmation feedback

## Technical
- `AIProvider` enum with auth, endpoints, models per provider
- `AIService` refactored with provider-specific request/response handling
- `TranscriptionManager` stores provider + model in UserDefaults
- `isAIConfigured` replaces `!openaiAPIKey.isEmpty` checks throughout

## Tests
14 new tests in `AIProviderTests` — providers, auth headers, response parsing (Anthropic + Google), JSON round-trips, error cases