### PR TITLE
feat: OpenAI OAuth — sign in with ChatGPT subscription

### DIFF
--- a/EchoNotes/Auth/OAuthCallbackServer.swift
+++ b/EchoNotes/Auth/OAuthCallbackServer.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Network
+import os
+
+/// Lightweight local HTTP server that listens for the OAuth callback.
+final class OAuthCallbackServer: @unchecked Sendable {
+    private let logger = Logger(subsystem: "com.echonotes", category: "OAuthServer")
+    private let port: UInt16
+    private let onCallback: @Sendable (String, String) -> Void // (code, state)
+    private var listener: NWListener?
+
+    init(port: UInt16, onCallback: @escaping @Sendable (String, String) -> Void) {
+        self.port = port
+        self.onCallback = onCallback
+    }
+
+    func start() throws {
+        let params = NWParameters.tcp
+        let listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
+        self.listener = listener
+
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handleConnection(connection)
+        }
+
+        listener.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                self?.logger.info("OAuth callback server listening on port \(self?.port ?? 0)")
+            case .failed(let error):
+                self?.logger.error("OAuth server failed: \(error.localizedDescription)")
+            default:
+                break
+            }
+        }
+
+        listener.start(queue: .global(qos: .userInitiated))
+    }
+
+    func stop() {
+        listener?.cancel()
+        listener = nil
+    }
+
+    private func handleConnection(_ connection: NWConnection) {
+        connection.start(queue: .global(qos: .userInitiated))
+
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { [weak self] data, _, _, error in
+            guard let self, let data, error == nil else {
+                connection.cancel()
+                return
+            }
+
+            guard let requestString = String(data: data, encoding: .utf8) else {
+                self.sendResponse(connection: connection, status: "400 Bad Request", body: "Invalid request")
+                return
+            }
+
+            // Parse the HTTP request line
+            guard let firstLine = requestString.split(separator: "\r\n").first else {
+                self.sendResponse(connection: connection, status: "400 Bad Request", body: "No request line")
+                return
+            }
+
+            let parts = firstLine.split(separator: " ")
+            guard parts.count >= 2 else {
+                self.sendResponse(connection: connection, status: "400 Bad Request", body: "Malformed request")
+                return
+            }
+
+            let path = String(parts[1])
+
+            // Parse the callback path
+            guard path.hasPrefix("/callback") else {
+                self.sendResponse(connection: connection, status: "404 Not Found", body: "Not found")
+                return
+            }
+
+            // Extract query parameters
+            guard let urlComponents = URLComponents(string: "http://localhost\(path)"),
+                  let queryItems = urlComponents.queryItems else {
+                self.sendResponse(connection: connection, status: "400 Bad Request", body: "No query parameters")
+                return
+            }
+
+            let params = Dictionary(uniqueKeysWithValues: queryItems.compactMap { item in
+                item.value.map { (item.name, $0) }
+            })
+
+            if let errorParam = params["error"] {
+                let desc = params["error_description"] ?? errorParam
+                self.sendResponse(connection: connection, status: "200 OK",
+                    body: self.errorHTML(message: desc))
+                return
+            }
+
+            guard let code = params["code"], let state = params["state"] else {
+                self.sendResponse(connection: connection, status: "400 Bad Request", body: "Missing code or state")
+                return
+            }
+
+            // Send success page to browser
+            self.sendResponse(connection: connection, status: "200 OK", body: self.successHTML())
+
+            // Fire the callback
+            self.onCallback(code, state)
+        }
+    }
+
+    private func sendResponse(connection: NWConnection, status: String, body: String) {
+        let isHTML = body.contains("<")
+        let contentType = isHTML ? "text/html; charset=utf-8" : "text/plain; charset=utf-8"
+        let response = """
+        HTTP/1.1 \(status)\r
+        Content-Type: \(contentType)\r
+        Content-Length: \(body.utf8.count)\r
+        Connection: close\r
+        \r
+        \(body)
+        """
+
+        connection.send(content: response.data(using: .utf8), completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    private func successHTML() -> String {
+        """
+        <!DOCTYPE html>
+        <html>
+        <head><title>EchoNotes — Signed In</title>
+        <style>
+            body { font-family: -apple-system, system-ui, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #e0e0e0; }
+            .card { text-align: center; padding: 40px; border-radius: 16px; background: #16213e; box-shadow: 0 4px 24px rgba(0,0,0,0.3); }
+            h1 { font-size: 24px; margin-bottom: 8px; }
+            p { color: #888; }
+        </style>
+        </head>
+        <body>
+            <div class="card">
+                <h1>✅ Signed in to EchoNotes</h1>
+                <p>You can close this tab and return to EchoNotes.</p>
+            </div>
+        </body>
+        </html>
+        """
+    }
+
+    private func errorHTML(message: String) -> String {
+        """
+        <!DOCTYPE html>
+        <html>
+        <head><title>EchoNotes — Error</title>
+        <style>
+            body { font-family: -apple-system, system-ui, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #e0e0e0; }
+            .card { text-align: center; padding: 40px; border-radius: 16px; background: #16213e; box-shadow: 0 4px 24px rgba(0,0,0,0.3); }
+            h1 { font-size: 24px; margin-bottom: 8px; color: #ff6b6b; }
+            p { color: #888; }
+        </style>
+        </head>
+        <body>
+            <div class="card">
+                <h1>❌ Authentication Failed</h1>
+                <p>\(message)</p>
+                <p>Close this tab and try again in EchoNotes.</p>
+            </div>
+        </body>
+        </html>
+        """
+    }
+}

--- a/EchoNotes/Auth/OAuthManager.swift
+++ b/EchoNotes/Auth/OAuthManager.swift
@@ -1,0 +1,370 @@
+import Foundation
+import CryptoKit
+import os
+
+/// Manages OpenAI OAuth 2.1 + PKCE authentication flow.
+/// Uses the same client ID and endpoints as OpenAI Codex CLI.
+@MainActor
+final class OAuthManager: ObservableObject {
+    private let logger = Logger(subsystem: "com.echonotes", category: "OAuth")
+
+    // OpenAI OAuth constants (same as Codex CLI)
+    static let clientId = "app_EMoamEEZ73f0CkXaXp7hrann"
+    static let issuer = "https://auth.openai.com"
+    static let authorizeURL = "\(issuer)/oauth/authorize"
+    static let tokenURL = "\(issuer)/oauth/token"
+    static let scopes = "openid profile email offline_access"
+
+    // Local callback server port
+    private static let callbackPort: UInt16 = 18923
+
+    @Published var isAuthenticating = false
+    @Published var isAuthenticated = false
+    @Published var error: String?
+    @Published var userEmail: String?
+
+    private var callbackServer: OAuthCallbackServer?
+    private var pkce: PKCECodes?
+    private var state: String?
+
+    /// Stored tokens
+    struct OAuthTokens: Codable {
+        var accessToken: String
+        var refreshToken: String
+        var idToken: String
+        var apiKey: String?
+        var email: String?
+        var expiresAt: Date?
+
+        var isExpired: Bool {
+            guard let exp = expiresAt else { return false }
+            return Date() > exp
+        }
+    }
+
+    private static let tokensKey = "oauthTokens"
+
+    /// Load stored tokens
+    var storedTokens: OAuthTokens? {
+        guard let data = UserDefaults.standard.data(forKey: Self.tokensKey),
+              let tokens = try? JSONDecoder().decode(OAuthTokens.self, from: data) else {
+            return nil
+        }
+        return tokens
+    }
+
+    init() {
+        if let tokens = storedTokens {
+            isAuthenticated = true
+            userEmail = tokens.email
+        }
+    }
+
+    // MARK: - PKCE
+
+    struct PKCECodes {
+        let codeVerifier: String
+        let codeChallenge: String
+    }
+
+    nonisolated static func generatePKCE() -> PKCECodes {
+        // Generate 32 random bytes → base64url
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        let verifier = Data(bytes).base64URLEncoded()
+
+        // SHA256 hash of verifier → base64url
+        let hash = SHA256.hash(data: Data(verifier.utf8))
+        let challenge = Data(hash).base64URLEncoded()
+
+        return PKCECodes(codeVerifier: verifier, codeChallenge: challenge)
+    }
+
+    nonisolated static func generateState() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes).base64URLEncoded()
+    }
+
+    // MARK: - Login Flow
+
+    /// Start the OAuth login flow.
+    func login() {
+        isAuthenticating = true
+        error = nil
+
+        let pkce = Self.generatePKCE()
+        let state = Self.generateState()
+        self.pkce = pkce
+        self.state = state
+
+        // Start local callback server
+        let server = OAuthCallbackServer(port: Self.callbackPort) { [weak self] code, returnedState in
+            Task { @MainActor in
+                guard let self else { return }
+                guard returnedState == self.state else {
+                    self.error = "OAuth state mismatch — possible CSRF attack"
+                    self.isAuthenticating = false
+                    return
+                }
+                await self.exchangeCodeForTokens(code: code)
+            }
+        }
+
+        do {
+            try server.start()
+            self.callbackServer = server
+        } catch {
+            self.error = "Failed to start callback server: \(error.localizedDescription)"
+            self.isAuthenticating = false
+            return
+        }
+
+        // Build authorization URL
+        let redirectURI = "http://localhost:\(Self.callbackPort)/callback"
+        var components = URLComponents(string: Self.authorizeURL)!
+        components.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: Self.clientId),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scope", value: Self.scopes),
+            URLQueryItem(name: "code_challenge", value: pkce.codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "codex_cli_simplified_flow", value: "true"),
+        ]
+
+        guard let authURL = components.url else {
+            self.error = "Failed to build authorization URL"
+            self.isAuthenticating = false
+            return
+        }
+
+        logger.info("Opening browser for OAuth: \(authURL.absoluteString)")
+        NSWorkspace.shared.open(authURL)
+    }
+
+    // MARK: - Token Exchange
+
+    /// Exchange the authorization code for tokens.
+    private func exchangeCodeForTokens(code: String) async {
+        guard let pkce else {
+            error = "PKCE not initialized"
+            isAuthenticating = false
+            return
+        }
+
+        let redirectURI = "http://localhost:\(Self.callbackPort)/callback"
+
+        // Step 1: Exchange code for id_token + access_token + refresh_token
+        let tokenBody = [
+            "grant_type=authorization_code",
+            "code=\(code.urlEncoded)",
+            "redirect_uri=\(redirectURI.urlEncoded)",
+            "client_id=\(Self.clientId.urlEncoded)",
+            "code_verifier=\(pkce.codeVerifier.urlEncoded)",
+        ].joined(separator: "&")
+
+        do {
+            var request = URLRequest(url: URL(string: Self.tokenURL)!)
+            request.httpMethod = "POST"
+            request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            request.httpBody = tokenBody.data(using: .utf8)
+            request.timeoutInterval = 30
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                let body = String(data: data, encoding: .utf8) ?? "unknown"
+                throw OAuthError.tokenExchangeFailed("Token exchange failed: \(body)")
+            }
+
+            struct TokenResponse: Decodable {
+                let id_token: String
+                let access_token: String
+                let refresh_token: String
+            }
+            let tokens = try JSONDecoder().decode(TokenResponse.self, from: data)
+
+            // Step 2: Exchange id_token for an API key
+            let apiKey = try await exchangeForAPIKey(idToken: tokens.id_token)
+
+            // Extract email from id_token JWT
+            let email = Self.extractEmailFromJWT(tokens.id_token)
+
+            // Store everything
+            let stored = OAuthTokens(
+                accessToken: tokens.access_token,
+                refreshToken: tokens.refresh_token,
+                idToken: tokens.id_token,
+                apiKey: apiKey,
+                email: email,
+                expiresAt: Date().addingTimeInterval(3600 * 8) // ~8 hours
+            )
+            saveTokens(stored)
+
+            isAuthenticated = true
+            userEmail = email
+            logger.info("OAuth login successful for \(email ?? "unknown")")
+        } catch {
+            self.error = error.localizedDescription
+            logger.error("OAuth error: \(error.localizedDescription)")
+        }
+
+        isAuthenticating = false
+        callbackServer?.stop()
+        callbackServer = nil
+    }
+
+    /// Exchange id_token for an OpenAI API key via token exchange grant.
+    private func exchangeForAPIKey(idToken: String) async throws -> String {
+        let body = [
+            "grant_type=\("urn:ietf:params:oauth:grant-type:token-exchange".urlEncoded)",
+            "client_id=\(Self.clientId.urlEncoded)",
+            "requested_token=\("openai-api-key".urlEncoded)",
+            "subject_token=\(idToken.urlEncoded)",
+            "subject_token_type=\("urn:ietf:params:oauth:token-type:id_token".urlEncoded)",
+        ].joined(separator: "&")
+
+        var request = URLRequest(url: URL(string: Self.tokenURL)!)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body.data(using: .utf8)
+        request.timeoutInterval = 30
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            let responseBody = String(data: data, encoding: .utf8) ?? "unknown"
+            throw OAuthError.apiKeyExchangeFailed("API key exchange failed: \(responseBody)")
+        }
+
+        struct ExchangeResponse: Decodable {
+            let access_token: String
+        }
+        let exchanged = try JSONDecoder().decode(ExchangeResponse.self, from: data)
+        return exchanged.access_token
+    }
+
+    // MARK: - Token Refresh
+
+    /// Refresh tokens using the stored refresh token.
+    func refreshTokensIfNeeded() async {
+        guard let tokens = storedTokens, tokens.isExpired else { return }
+
+        let body = [
+            "grant_type=refresh_token",
+            "client_id=\(Self.clientId.urlEncoded)",
+            "refresh_token=\(tokens.refreshToken.urlEncoded)",
+        ].joined(separator: "&")
+
+        do {
+            var request = URLRequest(url: URL(string: Self.tokenURL)!)
+            request.httpMethod = "POST"
+            request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body.data(using: .utf8)
+            request.timeoutInterval = 30
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                // Refresh failed — user needs to re-login
+                logout()
+                return
+            }
+
+            struct RefreshResponse: Decodable {
+                let id_token: String
+                let access_token: String
+                let refresh_token: String
+            }
+            let refreshed = try JSONDecoder().decode(RefreshResponse.self, from: data)
+
+            // Get new API key
+            let apiKey = try await exchangeForAPIKey(idToken: refreshed.id_token)
+            let email = Self.extractEmailFromJWT(refreshed.id_token)
+
+            let updated = OAuthTokens(
+                accessToken: refreshed.access_token,
+                refreshToken: refreshed.refresh_token,
+                idToken: refreshed.id_token,
+                apiKey: apiKey,
+                email: email,
+                expiresAt: Date().addingTimeInterval(3600 * 8)
+            )
+            saveTokens(updated)
+            userEmail = email
+            logger.info("Token refresh successful")
+        } catch {
+            logger.error("Token refresh failed: \(error.localizedDescription)")
+            logout()
+        }
+    }
+
+    // MARK: - Logout
+
+    func logout() {
+        UserDefaults.standard.removeObject(forKey: Self.tokensKey)
+        isAuthenticated = false
+        userEmail = nil
+        error = nil
+    }
+
+    // MARK: - Storage
+
+    private func saveTokens(_ tokens: OAuthTokens) {
+        if let data = try? JSONEncoder().encode(tokens) {
+            UserDefaults.standard.set(data, forKey: Self.tokensKey)
+        }
+    }
+
+    // MARK: - JWT Parsing
+
+    nonisolated static func extractEmailFromJWT(_ jwt: String) -> String? {
+        let parts = jwt.split(separator: ".")
+        guard parts.count >= 2 else { return nil }
+
+        var payload = String(parts[1])
+        // Add padding if needed
+        while payload.count % 4 != 0 { payload += "=" }
+        payload = payload.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        guard let data = Data(base64Encoded: payload),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json["email"] as? String
+    }
+}
+
+// MARK: - Errors
+
+enum OAuthError: LocalizedError {
+    case tokenExchangeFailed(String)
+    case apiKeyExchangeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .tokenExchangeFailed(let msg): return msg
+        case .apiKeyExchangeFailed(let msg): return msg
+        }
+    }
+}
+
+// MARK: - Extensions
+
+extension Data {
+    func base64URLEncoded() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+extension String {
+    var urlEncoded: String {
+        addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
+    }
+}

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -53,8 +53,15 @@ final class TranscriptionManager: ObservableObject {
         didSet { UserDefaults.standard.set(selectedAIModel, forKey: Self.aiModelDefaultsKey) }
     }
 
+    /// OAuth manager for ChatGPT login
+    let oauthManager = OAuthManager()
+
     /// Whether the current provider is configured and ready to use.
     var isAIConfigured: Bool {
+        // If using OpenAI with OAuth token, check that
+        if selectedProvider == .openai, let tokens = oauthManager.storedTokens, tokens.apiKey != nil {
+            return true
+        }
         if selectedProvider.requiresAPIKey {
             return !openaiAPIKey.isEmpty
         }
@@ -63,8 +70,14 @@ final class TranscriptionManager: ObservableObject {
 
     /// Build an AIService.Configuration from current settings.
     func aiConfiguration() -> AIService.Configuration {
-        AIService.Configuration(
-            apiKey: openaiAPIKey,
+        // Prefer OAuth API key for OpenAI if available
+        var apiKey = openaiAPIKey
+        if selectedProvider == .openai, let tokens = oauthManager.storedTokens, let oauthKey = tokens.apiKey {
+            apiKey = oauthKey
+        }
+
+        return AIService.Configuration(
+            apiKey: apiKey,
             model: selectedAIModel,
             endpoint: URL(string: selectedProvider.defaultEndpoint)!,
             provider: selectedProvider

--- a/EchoNotes/Views/SettingsView.swift
+++ b/EchoNotes/Views/SettingsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Settings page for app configuration (AI provider, model, etc).
+/// Settings page for app configuration (AI provider, model, OAuth, etc).
 struct SettingsView: View {
     @ObservedObject var tm: TranscriptionManager
     let onBack: () -> Void
@@ -25,6 +25,7 @@ struct SettingsView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
+                    oauthSection
                     aiProviderSection
                     aboutSection
                 }
@@ -35,6 +36,70 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - OAuth Section
+
+    private var oauthSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("Sign In with Account", systemImage: "person.crop.circle")
+                .font(.subheadline.bold())
+
+            Text("Sign in with your existing ChatGPT subscription instead of an API key. Your Plus/Pro plan includes API access.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if tm.oauthManager.isAuthenticated {
+                // Signed in state
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Signed in with ChatGPT")
+                            .font(.caption.bold())
+                        if let email = tm.oauthManager.userEmail {
+                            Text(email)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer()
+                    Button(action: { tm.oauthManager.logout() }) {
+                        Text("Sign Out")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            } else {
+                // Sign in button
+                Button(action: { tm.oauthManager.login() }) {
+                    HStack(spacing: 6) {
+                        if tm.oauthManager.isAuthenticating {
+                            ProgressView().controlSize(.mini)
+                            Text("Waiting for browser…")
+                        } else {
+                            Image(systemName: "arrow.right.circle.fill")
+                            Text("Sign in with ChatGPT")
+                        }
+                    }
+                    .font(.caption)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(tm.oauthManager.isAuthenticating)
+
+                if let error = tm.oauthManager.error {
+                    Text(error)
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .padding(12)
+        .background(Color.secondary.opacity(0.05))
+        .cornerRadius(8)
+    }
+
     // MARK: - AI Provider Section
 
     private var aiProviderSection: some View {
@@ -42,9 +107,20 @@ struct SettingsView: View {
             Label("AI Summarization", systemImage: "sparkles")
                 .font(.subheadline.bold())
 
-            Text("Choose an AI provider for meeting summaries. Your API key is stored locally and never sent anywhere except the provider's API.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            if tm.oauthManager.isAuthenticated && tm.selectedProvider == .openai {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.green)
+                    Text("Using your ChatGPT account for OpenAI API access")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Text("Choose an AI provider for meeting summaries. Your API key is stored locally and never sent anywhere except the provider's API.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
 
             // Provider picker
             VStack(alignment: .leading, spacing: 6) {
@@ -60,7 +136,6 @@ struct SettingsView: View {
                 .pickerStyle(.segmented)
                 .onChange(of: tm.selectedProvider) { _, newValue in
                     tm.selectedAIModel = newValue.defaultModel
-                    // Clear key when switching providers (different key formats)
                     if newValue.requiresAPIKey && apiKeyInput.isEmpty {
                         apiKeyInput = ""
                     }
@@ -81,8 +156,8 @@ struct SettingsView: View {
                 .pickerStyle(.menu)
             }
 
-            // API Key (if required)
-            if tm.selectedProvider.requiresAPIKey {
+            // API Key (if required and not using OAuth)
+            if tm.selectedProvider.requiresAPIKey && !(tm.oauthManager.isAuthenticated && tm.selectedProvider == .openai) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("API Key")
                         .font(.caption.bold())
@@ -142,8 +217,8 @@ struct SettingsView: View {
                         }
                     }
                 }
-            } else {
-                // Ollama — no key needed, just check if it's running
+            } else if !tm.selectedProvider.requiresAPIKey {
+                // Ollama
                 HStack(spacing: 4) {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.caption2)

--- a/EchoNotesTests/OAuthManagerTests.swift
+++ b/EchoNotesTests/OAuthManagerTests.swift
@@ -1,0 +1,162 @@
+import Testing
+import Foundation
+@testable import EchoNotes
+
+@Suite("OAuthManager")
+struct OAuthManagerTests {
+
+    // MARK: - PKCE
+
+    @Test("PKCE generates valid code verifier")
+    func pkceVerifier() {
+        let pkce = OAuthManager.generatePKCE()
+        #expect(!pkce.codeVerifier.isEmpty)
+        #expect(pkce.codeVerifier.count >= 32)
+        // Base64URL should not contain +, /, or =
+        #expect(!pkce.codeVerifier.contains("+"))
+        #expect(!pkce.codeVerifier.contains("/"))
+        #expect(!pkce.codeVerifier.contains("="))
+    }
+
+    @Test("PKCE generates valid code challenge")
+    func pkceChallenge() {
+        let pkce = OAuthManager.generatePKCE()
+        #expect(!pkce.codeChallenge.isEmpty)
+        // Challenge should be different from verifier (it's a hash)
+        #expect(pkce.codeChallenge != pkce.codeVerifier)
+        // Base64URL format
+        #expect(!pkce.codeChallenge.contains("+"))
+        #expect(!pkce.codeChallenge.contains("/"))
+        #expect(!pkce.codeChallenge.contains("="))
+    }
+
+    @Test("PKCE generates unique pairs each time")
+    func pkceUnique() {
+        let a = OAuthManager.generatePKCE()
+        let b = OAuthManager.generatePKCE()
+        #expect(a.codeVerifier != b.codeVerifier)
+        #expect(a.codeChallenge != b.codeChallenge)
+    }
+
+    // MARK: - State Generation
+
+    @Test("State generation produces unique values")
+    func stateUnique() {
+        let a = OAuthManager.generateState()
+        let b = OAuthManager.generateState()
+        #expect(a != b)
+        #expect(!a.isEmpty)
+    }
+
+    @Test("State is base64url encoded")
+    func stateFormat() {
+        let state = OAuthManager.generateState()
+        #expect(!state.contains("+"))
+        #expect(!state.contains("/"))
+        #expect(!state.contains("="))
+    }
+
+    // MARK: - JWT Parsing
+
+    @Test("Extract email from valid JWT")
+    func extractEmailFromJWT() {
+        // Create a fake JWT with email in payload
+        let header = Data("{}".utf8).base64URLEncoded()
+        let payload = Data(#"{"email":"test@example.com","sub":"user123"}"#.utf8).base64URLEncoded()
+        let signature = "fakesig"
+        let jwt = "\(header).\(payload).\(signature)"
+
+        let email = OAuthManager.extractEmailFromJWT(jwt)
+        #expect(email == "test@example.com")
+    }
+
+    @Test("Extract email returns nil for JWT without email")
+    func extractEmailNoEmail() {
+        let header = Data("{}".utf8).base64URLEncoded()
+        let payload = Data(#"{"sub":"user123"}"#.utf8).base64URLEncoded()
+        let jwt = "\(header).\(payload).sig"
+
+        let email = OAuthManager.extractEmailFromJWT(jwt)
+        #expect(email == nil)
+    }
+
+    @Test("Extract email returns nil for invalid JWT")
+    func extractEmailInvalidJWT() {
+        #expect(OAuthManager.extractEmailFromJWT("not-a-jwt") == nil)
+        #expect(OAuthManager.extractEmailFromJWT("") == nil)
+        #expect(OAuthManager.extractEmailFromJWT("a.b") == nil)
+    }
+
+    // MARK: - Token Storage
+
+    @Test("OAuthTokens round-trip JSON encoding")
+    func tokensRoundTrip() throws {
+        let tokens = OAuthManager.OAuthTokens(
+            accessToken: "acc_123",
+            refreshToken: "ref_456",
+            idToken: "id_789",
+            apiKey: "sk-test",
+            email: "user@example.com",
+            expiresAt: Date(timeIntervalSince1970: 1700000000)
+        )
+        let encoded = try JSONEncoder().encode(tokens)
+        let decoded = try JSONDecoder().decode(OAuthManager.OAuthTokens.self, from: encoded)
+        #expect(decoded.accessToken == "acc_123")
+        #expect(decoded.refreshToken == "ref_456")
+        #expect(decoded.apiKey == "sk-test")
+        #expect(decoded.email == "user@example.com")
+    }
+
+    @Test("Token expiry check works")
+    func tokenExpiry() {
+        let expired = OAuthManager.OAuthTokens(
+            accessToken: "a", refreshToken: "r", idToken: "i",
+            expiresAt: Date().addingTimeInterval(-3600)
+        )
+        #expect(expired.isExpired)
+
+        let valid = OAuthManager.OAuthTokens(
+            accessToken: "a", refreshToken: "r", idToken: "i",
+            expiresAt: Date().addingTimeInterval(3600)
+        )
+        #expect(!valid.isExpired)
+    }
+
+    @Test("Token without expiry is not expired")
+    func tokenNoExpiry() {
+        let tokens = OAuthManager.OAuthTokens(
+            accessToken: "a", refreshToken: "r", idToken: "i",
+            expiresAt: nil
+        )
+        #expect(!tokens.isExpired)
+    }
+
+    // MARK: - Constants
+
+    @Test("OAuth constants match Codex CLI")
+    func constants() {
+        #expect(OAuthManager.clientId == "app_EMoamEEZ73f0CkXaXp7hrann")
+        #expect(OAuthManager.issuer == "https://auth.openai.com")
+        #expect(OAuthManager.tokenURL == "https://auth.openai.com/oauth/token")
+    }
+
+    // MARK: - URL Encoding
+
+    @Test("URL encoding handles special characters")
+    func urlEncoding() {
+        let input = "hello world+test/path=value"
+        let encoded = input.urlEncoded
+        #expect(!encoded.contains(" "))
+    }
+
+    // MARK: - Base64URL
+
+    @Test("Base64URL encoding removes padding and substitutes chars")
+    func base64URL() {
+        let data = Data([0xFF, 0xFE, 0xFD, 0xFC]) // Will produce + and / in regular base64
+        let encoded = data.base64URLEncoded()
+        #expect(!encoded.contains("+"))
+        #expect(!encoded.contains("/"))
+        #expect(!encoded.contains("="))
+    }
+}


### PR DESCRIPTION
## What
Users can now sign in with their existing ChatGPT Plus/Pro subscription instead of getting a separate API key. Uses the same OAuth flow as OpenAI Codex CLI.

## How It Works
1. Click 'Sign in with ChatGPT' in Settings
2. Browser opens → authenticate with your ChatGPT account
3. App catches the callback, exchanges tokens, gets an API key
4. AI summarization works immediately — no API key to paste

## Technical
- OAuth 2.1 + PKCE flow (same as Codex CLI)
- Client ID: `app_EMoamEEZ73f0CkXaXp7hrann` (OpenAI's registered app)
- Issuer: `https://auth.openai.com`
- Local HTTP callback server on port 18923
- Token refresh support (auto-refreshes before expiry)
- Falls back to manual API key if user prefers

## Settings UI
- OAuth section at top: Sign in / signed-in status with email / Sign out
- When signed in with ChatGPT + OpenAI selected: hides API key field
- Other providers (Anthropic, Google, Ollama) still use API key entry

## Tests
18 new tests covering PKCE, state generation, JWT parsing, token storage, and constants.

Closes #119