### PR TITLE
fix: AIService build error — extraneous closing brace

### DIFF
--- a/EchoNotes/AI/AIService.swift
+++ b/EchoNotes/AI/AIService.swift
@@ -215,7 +215,6 @@ final class AIService: Sendable {
 
         return try JSONDecoder().decode(MeetingSummary.self, from: summaryData)
     }
-}
 
     /// Parse Anthropic messages API response.
     func parseAnthropicResponse(_ data: Data) throws -> MeetingSummary {


### PR DESCRIPTION
Removes a premature `}` that closed the AIService class before the Anthropic and Google response parsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->