### PR TITLE
fix: add missing AppKit import in OAuthManager

### DIFF
--- a/EchoNotes/Auth/OAuthManager.swift
+++ b/EchoNotes/Auth/OAuthManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import CryptoKit
 import os
 


### PR DESCRIPTION
NSWorkspace requires AppKit. Missing import caused build error.