### PR TITLE
Fix: Handle microphone disconnection without losing recording

### DIFF
--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -105,6 +105,9 @@ final class RecordingEngine: ObservableObject {
 
             audioWriter = writer
 
+            // Clear any previous microphone warnings
+            micCapture.clearWarning()
+
             // Surface audio capture errors to the UI
             systemCapture.onError = { [weak self] error in
                 Task { @MainActor in
@@ -123,6 +126,16 @@ final class RecordingEngine: ObservableObject {
                 Task { @MainActor in
                     self?.errorMessage = "Microphone error: \(error.localizedDescription)"
                     await self?.stopRecording()
+                }
+            }
+
+            // Surface microphone warnings (non-fatal, recording continues)
+            micCapture.onWarning = { [weak self] warning in
+                Task { @MainActor in
+                    // Don't overwrite existing errors with warnings
+                    if self?.errorMessage == nil {
+                        self?.errorMessage = warning
+                    }
                 }
             }
 

--- a/EchoNotes/Audio/MicrophoneCapture.swift
+++ b/EchoNotes/Audio/MicrophoneCapture.swift
@@ -22,9 +22,8 @@ final class MicrophoneCapture: @unchecked Sendable {
     private let logger = Logger(subsystem: "com.echonotes", category: "MicrophoneCapture")
     private var configObserver: NSObjectProtocol?
     private var _hasWarning = OSAllocatedUnfairLock(initialState: false)
-    private let maxBufferLag = Int(AudioConfig.sampleRate) * 10
-    private var disconnectedSamples: [Float] = []
-    private var disconnectedOffset = 0
+    private var isDisconnected = false
+    private var silenceTimer: Timer?
 
     func startCapture(sampleRate: Double = AudioConfig.sampleRate) throws {
         guard _isCapturing.withLock({ !$0 }) else { return }
@@ -71,11 +70,15 @@ final class MicrophoneCapture: @unchecked Sendable {
                 return false
             }
             if wasCapturing {
+                guard !self.isDisconnected else { return } // Already handling disconnection
+                self.isDisconnected = true
                 self._hasWarning.withLock { $0 = true }
                 self.logger.warning("Microphone disconnected - recording will continue with system audio only")
                 self.onWarning?("Microphone disconnected - recording will continue with system audio only")
-                // Stop the engine but keep the capture object alive
+                
+                // Stop the engine but keep feeding silence to onBuffer to stay in sync
                 self.engine.stop()
+                self.startSilenceFeed()
             }
         }
 
@@ -94,19 +97,18 @@ final class MicrophoneCapture: @unchecked Sendable {
             configObserver = nil
         }
         
-        if !engine.isRunning {
-            // Engine already stopped due to disconnection - pad with silence
+        if isDisconnected {
+            // Engine was stopped due to disconnection - stop the silence feed
+            silenceTimer?.invalidate()
+            silenceTimer = nil
+            isDisconnected = false
+        }
+        
+        guard engine.isRunning else {
+            // Engine not running but not in disconnected state - cleanup and return
             lock.lock()
-            let sysAvailable = disconnectedSamples.count - disconnectedOffset
-            let micAvailable = disconnectedSamples.count - disconnectedOffset
-            
-            // Pad the shorter stream with silence
-            let maxCount = max(sysAvailable, micAvailable)
-            if maxCount > 0 {
-                while (disconnectedSamples.count - disconnectedOffset) < maxCount {
-                    disconnectedSamples.append(0)
-                }
-            }
+            converter = nil
+            targetFormat = nil
             lock.unlock()
             return
         }
@@ -150,6 +152,18 @@ final class MicrophoneCapture: @unchecked Sendable {
         let samples = Array(UnsafeBufferPointer(start: channelData[0], count: Int(outputBuffer.frameLength)))
 
         onBuffer?(SourcedAudioBuffer(samples: samples, source: .microphone))
+    }
+    
+    /// Starts feeding silence buffers to onBuffer to keep stereo file synchronized
+    private func startSilenceFeed() {
+        // Feed silence at ~48kHz, matching the audio writer's expected rate
+        // Using 4096-sample chunks to match the tap buffer size
+        let bufferSize = 4096
+        silenceTimer = Timer.scheduledTimer(withTimeInterval: 0.085, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            let silence = Array(repeating: Float(0.0), count: bufferSize)
+            self.onBuffer?(SourcedAudioBuffer(samples: silence, source: .microphone))
+        }
     }
 }
 

--- a/EchoNotes/Audio/MicrophoneCapture.swift
+++ b/EchoNotes/Audio/MicrophoneCapture.swift
@@ -19,25 +19,33 @@ final class MicrophoneCapture: @unchecked Sendable {
     private var converter: AVAudioConverter?
     private var targetFormat: AVAudioFormat?
     private let _isCapturing = OSAllocatedUnfairLock(initialState: false)
+    private let _hasWarning = OSAllocatedUnfairLock(initialState: false)
+    private let _isDisconnected = OSAllocatedUnfairLock(initialState: false)
     private let logger = Logger(subsystem: "com.echonotes", category: "MicrophoneCapture")
     private var configObserver: NSObjectProtocol?
-    private var _hasWarning = OSAllocatedUnfairLock(initialState: false)
-    private var isDisconnected = false
-    private var silenceTimer: Timer?
+    private var silenceTimer: DispatchSourceTimer?
 
     func startCapture(sampleRate: Double = AudioConfig.sampleRate) throws {
         guard _isCapturing.withLock({ !$0 }) else { return }
 
         let fmt = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: sampleRate, channels: 1, interleaved: false)!
 
+        // Store target format early for future recovery attempts
+        lock.lock()
+        targetFormat = fmt
+        lock.unlock()
+
         let inputNode = engine.inputNode
         let inputFormat = inputNode.outputFormat(forBus: 0)
-        guard inputFormat.sampleRate > 0 else { 
-            // No input device - start in disconnected state
-            self._hasWarning.withLock { $0 = true }
-            self.logger.warning("No microphone input device - recording will continue with system audio only")
-            self.onWarning?("No microphone input device - recording will continue with system audio only")
+
+        // No input device — start in disconnected state with silence feed
+        if inputFormat.sampleRate <= 0 {
+            _hasWarning.withLock { $0 = true }
+            _isDisconnected.withLock { $0 = true }
             _isCapturing.withLock { $0 = true }
+            logger.warning("No microphone input device - recording will continue with system audio only")
+            onWarning?("No microphone input device - recording will continue with system audio only")
+            startSilenceFeed()
             return
         }
 
@@ -45,7 +53,6 @@ final class MicrophoneCapture: @unchecked Sendable {
         guard conv != nil else { throw MicrophoneError.converterCreationFailed }
 
         lock.lock()
-        targetFormat = fmt
         converter = conv
         lock.unlock()
 
@@ -60,65 +67,7 @@ final class MicrophoneCapture: @unchecked Sendable {
             queue: .main
         ) { [weak self] _ in
             guard let self else { return }
-            // Atomically check and update _isCapturing to avoid races with stopCapture()
-            let wasCapturing = self._isCapturing.withLock { current -> Bool in
-                guard current else { return false }
-                if !self.engine.isRunning {
-                    current = false
-                    return true
-                }
-                return false
-            }
-            guard wasCapturing else { return }
-            
-            // Check if we already have a silence feed running
-            if self.isDisconnected {
-                // Already in disconnected state - try to recover
-                self.tryRecoverFromDisconnection()
-                return
-            }
-            
-            // Engine stopped due to config change - try to restart with new device
-            self.logger.info("Microphone configuration changed, attempting to recover...")
-            
-            // Stop the tap first
-            self.engine.inputNode.removeTap(onBus: 0)
-            
-            // Try to restart the engine with the new device
-            let newFormat = self.engine.inputNode.outputFormat(forBus: 0)
-            guard newFormat.sampleRate > 0 else {
-                // No valid device available - fall back to silence
-                self.handlePermanentDisconnection()
-                return
-            }
-            
-            // Update converter for new format
-            self.lock.lock()
-            let conv = AVAudioConverter(from: newFormat, to: self.targetFormat!)
-            self.converter = conv
-            self.lock.unlock()
-            
-            guard conv != nil else {
-                self.handlePermanentDisconnection()
-                return
-            }
-            
-            // Reinstall tap with new format
-            self.engine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: newFormat) { [weak self] buffer, _ in
-                self?.processBuffer(buffer)
-            }
-            
-            // Restart engine
-            do {
-                self.engine.prepare()
-                try self.engine.start()
-                self.logger.info("Microphone recovered - now using new device")
-                // Clear warning state if it was set
-                self._hasWarning.withLock { $0 = false }
-            } catch {
-                self.logger.warning("Failed to restart microphone: \(error.localizedDescription)")
-                self.handlePermanentDisconnection()
-            }
+            self.handleConfigurationChange()
         }
 
         engine.prepare()
@@ -128,30 +77,29 @@ final class MicrophoneCapture: @unchecked Sendable {
 
     func stopCapture() {
         guard _isCapturing.withLock({ $0 }) else { return }
-        
+
         _isCapturing.withLock { $0 = false }
-        
+
         if let observer = configObserver {
             NotificationCenter.default.removeObserver(observer)
             configObserver = nil
         }
-        
-        if isDisconnected {
-            // Engine was stopped due to disconnection - stop the silence feed
-            silenceTimer?.invalidate()
+
+        // Stop silence timer if running
+        if _isDisconnected.withLock({ $0 }) {
+            silenceTimer?.cancel()
             silenceTimer = nil
-            isDisconnected = false
+            _isDisconnected.withLock { $0 = false }
         }
-        
+
         guard engine.isRunning else {
-            // Engine not running but not in disconnected state - cleanup and return
             lock.lock()
             converter = nil
             targetFormat = nil
             lock.unlock()
             return
         }
-        
+
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
 
@@ -160,6 +108,137 @@ final class MicrophoneCapture: @unchecked Sendable {
         targetFormat = nil
         lock.unlock()
     }
+
+    // MARK: - Configuration Change Handler
+
+    private func handleConfigurationChange() {
+        // Check if we're still capturing and engine stopped
+        let wasCapturing = _isCapturing.withLock { current -> Bool in
+            guard current else { return false }
+            if !engine.isRunning {
+                current = false
+                return true
+            }
+            return false
+        }
+
+        guard wasCapturing else { return }
+
+        // If already disconnected, try to recover (new device plugged in)
+        if _isDisconnected.withLock({ $0 }) {
+            attemptRecovery()
+            return
+        }
+
+        // Engine stopped — attempt to restart with new/changed device
+        logger.info("Microphone configuration changed, attempting to recover...")
+
+        // Remove existing tap before restart
+        engine.inputNode.removeTap(onBus: 0)
+
+        // Try to restart
+        if attemptRestart() {
+            logger.info("Microphone recovered - now using new device")
+            _hasWarning.withLock { $0 = false }
+        } else {
+            logger.warning("Failed to restart microphone - falling back to silence")
+            handleDisconnection()
+        }
+    }
+
+    // MARK: - Recovery Logic
+
+    /// Attempts to restart the engine with the current input device.
+    /// - Returns: true if restart succeeded
+    private func attemptRestart() -> Bool {
+        let deviceFormat = engine.inputNode.outputFormat(forBus: 0)
+        guard deviceFormat.sampleRate > 0 else { return false }
+
+        // Get target format (safe unwrap — set in startCapture before any path)
+        lock.lock()
+        guard let target = targetFormat else {
+            lock.unlock()
+            return false
+        }
+        lock.unlock()
+
+        let conv = AVAudioConverter(from: deviceFormat, to: target)
+        guard conv != nil else { return false }
+
+        lock.lock()
+        converter = conv
+        lock.unlock()
+
+        // Reinstall tap with new format
+        engine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: deviceFormat) { [weak self] buffer, _ in
+            self?.processBuffer(buffer)
+        }
+
+        // Restart engine
+        do {
+            engine.prepare()
+            try engine.start()
+            return true
+        } catch {
+            logger.warning("Failed to restart engine: \(error.localizedDescription)")
+            // Clean up tap if engine failed to start
+            engine.inputNode.removeTap(onBus: 0)
+            return false
+        }
+    }
+
+    /// Attempts to recover from disconnection state when a new device appears
+    private func attemptRecovery() {
+        // Stop silence feed temporarily
+        silenceTimer?.cancel()
+        silenceTimer = nil
+
+        // Remove any leftover tap
+        engine.inputNode.removeTap(onBus: 0)
+
+        if attemptRestart() {
+            _isDisconnected.withLock { $0 = false }
+            _hasWarning.withLock { $0 = false }
+            logger.info("Microphone recovered - recording resumed with new device")
+        } else {
+            // Still no device — restart silence feed
+            startSilenceFeed()
+        }
+    }
+
+    /// Handles disconnection by starting silence feed
+    private func handleDisconnection() {
+        guard !_isDisconnected.withLock({ $0 }) else { return }
+
+        _isDisconnected.withLock { $0 = true }
+        _hasWarning.withLock { $0 = true }
+
+        logger.warning("Microphone unavailable - recording will continue with system audio only")
+        onWarning?("Microphone unavailable - recording will continue with system audio only")
+
+        startSilenceFeed()
+    }
+
+    // MARK: - Silence Feed
+
+    /// Starts feeding silence buffers to onBuffer to keep stereo file synchronized.
+    /// Uses DispatchSourceTimer for precise timing independent of RunLoop.
+    private func startSilenceFeed() {
+        let bufferSize = 4096
+        let intervalMs = 85 // ~4096 samples at 48kHz ≈ 85ms per chunk
+
+        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .userInitiated))
+        timer.schedule(deadline: .now(), repeating: .milliseconds(intervalMs), leeway: .milliseconds(5))
+        timer.setEventHandler { [weak self] in
+            guard let self, self._isCapturing.withLock({ $0 }) else { return }
+            let silence = Array(repeating: Float(0.0), count: bufferSize)
+            self.onBuffer?(SourcedAudioBuffer(samples: silence, source: .microphone))
+        }
+        timer.resume()
+        silenceTimer = timer
+    }
+
+    // MARK: - Buffer Processing
 
     private func processBuffer(_ buffer: AVAudioPCMBuffer) {
         lock.lock()
@@ -191,72 +270,6 @@ final class MicrophoneCapture: @unchecked Sendable {
         let samples = Array(UnsafeBufferPointer(start: channelData[0], count: Int(outputBuffer.frameLength)))
 
         onBuffer?(SourcedAudioBuffer(samples: samples, source: .microphone))
-    }
-    
-    /// Starts feeding silence buffers to onBuffer to keep stereo file synchronized
-    private func startSilenceFeed() {
-        // Feed silence at ~48kHz, matching the audio writer's expected rate
-        // Using 4096-sample chunks to match the tap buffer size
-        let bufferSize = 4096
-        silenceTimer = Timer.scheduledTimer(withTimeInterval: 0.085, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            let silence = Array(repeating: Float(0.0), count: bufferSize)
-            self.onBuffer?(SourcedAudioBuffer(samples: silence, source: .microphone))
-        }
-    }
-    
-    /// Called when engine stops due to config change and we need to fall back to silence
-    private func handlePermanentDisconnection() {
-        guard !isDisconnected else { return }
-        isDisconnected = true
-        _hasWarning.withLock { $0 = true }
-        logger.warning("Microphone unavailable - recording will continue with system audio only")
-        onWarning?("Microphone unavailable - recording will continue with system audio only")
-        startSilenceFeed()
-    }
-    
-    /// Attempts to recover from a disconnection by checking if a new device is available
-    private func tryRecoverFromDisconnection() {
-        // Stop the silence feed temporarily
-        silenceTimer?.invalidate()
-        silenceTimer = nil
-        
-        // Check if we have a valid device now
-        let newFormat = engine.inputNode.outputFormat(forBus: 0)
-        guard newFormat.sampleRate > 0 else {
-            // Still no device - restart silence feed
-            startSilenceFeed()
-            return
-        }
-        
-        // Try to restart with new device
-        lock.lock()
-        let conv = AVAudioConverter(from: newFormat, to: targetFormat!)
-        converter = conv
-        lock.unlock()
-        
-        guard conv != nil else {
-            startSilenceFeed()
-            return
-        }
-        
-        // Reinstall tap
-        engine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: newFormat) { [weak self] buffer, _ in
-            self?.processBuffer(buffer)
-        }
-        
-        // Restart engine
-        do {
-            engine.prepare()
-            try engine.start()
-            isDisconnected = false
-            _hasWarning.withLock { $0 = false }
-            logger.info("Microphone recovered - recording resumed with new device")
-        } catch {
-            logger.warning("Recovery failed: \(error.localizedDescription)")
-            isDisconnected = true
-            startSilenceFeed()
-        }
     }
 }
 

--- a/EchoNotes/Audio/MicrophoneCapture.swift
+++ b/EchoNotes/Audio/MicrophoneCapture.swift
@@ -69,16 +69,55 @@ final class MicrophoneCapture: @unchecked Sendable {
                 }
                 return false
             }
-            if wasCapturing {
-                guard !self.isDisconnected else { return } // Already handling disconnection
-                self.isDisconnected = true
-                self._hasWarning.withLock { $0 = true }
-                self.logger.warning("Microphone disconnected - recording will continue with system audio only")
-                self.onWarning?("Microphone disconnected - recording will continue with system audio only")
-                
-                // Stop the engine but keep feeding silence to onBuffer to stay in sync
-                self.engine.stop()
-                self.startSilenceFeed()
+            guard wasCapturing else { return }
+            
+            // Check if we already have a silence feed running
+            if self.isDisconnected {
+                // Already in disconnected state - try to recover
+                self.tryRecoverFromDisconnection()
+                return
+            }
+            
+            // Engine stopped due to config change - try to restart with new device
+            self.logger.info("Microphone configuration changed, attempting to recover...")
+            
+            // Stop the tap first
+            self.engine.inputNode.removeTap(onBus: 0)
+            
+            // Try to restart the engine with the new device
+            let newFormat = self.engine.inputNode.outputFormat(forBus: 0)
+            guard newFormat.sampleRate > 0 else {
+                // No valid device available - fall back to silence
+                self.handlePermanentDisconnection()
+                return
+            }
+            
+            // Update converter for new format
+            self.lock.lock()
+            let conv = AVAudioConverter(from: newFormat, to: self.targetFormat!)
+            self.converter = conv
+            self.lock.unlock()
+            
+            guard conv != nil else {
+                self.handlePermanentDisconnection()
+                return
+            }
+            
+            // Reinstall tap with new format
+            self.engine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: newFormat) { [weak self] buffer, _ in
+                self?.processBuffer(buffer)
+            }
+            
+            // Restart engine
+            do {
+                self.engine.prepare()
+                try self.engine.start()
+                self.logger.info("Microphone recovered - now using new device")
+                // Clear warning state if it was set
+                self._hasWarning.withLock { $0 = false }
+            } catch {
+                self.logger.warning("Failed to restart microphone: \(error.localizedDescription)")
+                self.handlePermanentDisconnection()
             }
         }
 
@@ -163,6 +202,60 @@ final class MicrophoneCapture: @unchecked Sendable {
             guard let self else { return }
             let silence = Array(repeating: Float(0.0), count: bufferSize)
             self.onBuffer?(SourcedAudioBuffer(samples: silence, source: .microphone))
+        }
+    }
+    
+    /// Called when engine stops due to config change and we need to fall back to silence
+    private func handlePermanentDisconnection() {
+        guard !isDisconnected else { return }
+        isDisconnected = true
+        _hasWarning.withLock { $0 = true }
+        logger.warning("Microphone unavailable - recording will continue with system audio only")
+        onWarning?("Microphone unavailable - recording will continue with system audio only")
+        startSilenceFeed()
+    }
+    
+    /// Attempts to recover from a disconnection by checking if a new device is available
+    private func tryRecoverFromDisconnection() {
+        // Stop the silence feed temporarily
+        silenceTimer?.invalidate()
+        silenceTimer = nil
+        
+        // Check if we have a valid device now
+        let newFormat = engine.inputNode.outputFormat(forBus: 0)
+        guard newFormat.sampleRate > 0 else {
+            // Still no device - restart silence feed
+            startSilenceFeed()
+            return
+        }
+        
+        // Try to restart with new device
+        lock.lock()
+        let conv = AVAudioConverter(from: newFormat, to: targetFormat!)
+        converter = conv
+        lock.unlock()
+        
+        guard conv != nil else {
+            startSilenceFeed()
+            return
+        }
+        
+        // Reinstall tap
+        engine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: newFormat) { [weak self] buffer, _ in
+            self?.processBuffer(buffer)
+        }
+        
+        // Restart engine
+        do {
+            engine.prepare()
+            try engine.start()
+            isDisconnected = false
+            _hasWarning.withLock { $0 = false }
+            logger.info("Microphone recovered - recording resumed with new device")
+        } catch {
+            logger.warning("Recovery failed: \(error.localizedDescription)")
+            isDisconnected = true
+            startSilenceFeed()
         }
     }
 }

--- a/EchoNotesTests/MicrophoneCaptureTests.swift
+++ b/EchoNotesTests/MicrophoneCaptureTests.swift
@@ -31,7 +31,7 @@ struct MicrophoneCaptureTests {
         // Start capture - if no device is available, it should enter disconnected state
         // Note: This test behavior depends on system state
         do {
-            try await capture.startCapture(sampleRate: 48000)
+            try capture.startCapture(sampleRate: 48000)
             
             // Give it a moment to initialize
             try await Task.sleep(nanoseconds: 100_000_000) // 100ms
@@ -55,7 +55,7 @@ struct MicrophoneCaptureTests {
         // Start and stop multiple times to verify cleanup works
         for _ in 0..<3 {
             do {
-                try await capture.startCapture(sampleRate: 48000)
+                try capture.startCapture(sampleRate: 48000)
                 try await Task.sleep(nanoseconds: 50_000_000) // 50ms
             } catch {
                 // Continue even if start fails
@@ -91,7 +91,7 @@ struct MicrophoneCaptureTests {
         
         for i in 0..<5 {
             do {
-                try await capture.startCapture(sampleRate: 48000)
+                try capture.startCapture(sampleRate: 48000)
                 _ = i // Use variable to avoid unused warning
                 try await Task.sleep(nanoseconds: 25_000_000) // 25ms
             } catch {

--- a/EchoNotesTests/MicrophoneCaptureTests.swift
+++ b/EchoNotesTests/MicrophoneCaptureTests.swift
@@ -1,0 +1,106 @@
+import Testing
+import AVFoundation
+@testable import EchoNotes
+
+@Suite("MicrophoneCapture Tests")
+struct MicrophoneCaptureTests {
+    
+    @Test("clearWarning resets warning state")
+    func clearWarningResetsState() async throws {
+        let capture = MicrophoneCapture()
+        
+        // Initially no warning
+        #expect(!capture.hasWarning)
+        
+        // Simulate warning state by accessing internal lock
+        // (In real usage, this would be set by handlePermanentDisconnection)
+        // We can't directly test the private lock, but we can verify clearWarning doesn't crash
+        capture.clearWarning()
+        #expect(!capture.hasWarning)
+    }
+    
+    @Test("startCapture handles missing device gracefully")
+    func startCaptureWithNoDevice() async throws {
+        let capture = MicrophoneCapture()
+        var warningReceived = false
+        
+        capture.onWarning = { _ in
+            warningReceived = true
+        }
+        
+        // Start capture - if no device is available, it should enter disconnected state
+        // Note: This test behavior depends on system state
+        do {
+            try await capture.startCapture(sampleRate: 48000)
+            
+            // Give it a moment to initialize
+            try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+            
+            // Clean up
+            capture.stopCapture()
+            
+            // If warning was received, that's expected when no mic is available
+            // If not, that means a mic was found (also valid)
+            // Either way, no crash = success
+        } catch {
+            // Error is also acceptable if device setup fails
+            capture.stopCapture()
+        }
+    }
+    
+    @Test("stopCapture cleans up resources")
+    func stopCaptureCleansUp() async throws {
+        let capture = MicrophoneCapture()
+        
+        // Start and stop multiple times to verify cleanup works
+        for _ in 0..<3 {
+            do {
+                try await capture.startCapture(sampleRate: 48000)
+                try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            } catch {
+                // Continue even if start fails
+            }
+            capture.stopCapture()
+        }
+        
+        // Should complete without crash
+        #expect(true)
+    }
+    
+    @Test("onWarning callback is invoked")
+    func onWarningCallback() async throws {
+        let capture = MicrophoneCapture()
+        var receivedWarning: String?
+        
+        capture.onWarning = { warning in
+            receivedWarning = warning
+        }
+        
+        // We can't directly trigger the warning without a real disconnection,
+        // but we can verify the callback slot is settable and clearWarning works
+        capture.clearWarning()
+        #expect(!capture.hasWarning)
+        
+        // Callback assignment doesn't crash = success
+        #expect(true)
+    }
+    
+    @Test("multiple start/stop cycles don't leak state")
+    func multipleStartStopCycles() async throws {
+        let capture = MicrophoneCapture()
+        
+        for i in 0..<5 {
+            do {
+                try await capture.startCapture(sampleRate: 48000)
+                _ = i // Use variable to avoid unused warning
+                try await Task.sleep(nanoseconds: 25_000_000) // 25ms
+            } catch {
+                // Expected in some environments
+            }
+            capture.stopCapture()
+        }
+        
+        // Should complete without crash or state leak
+        #expect(true)
+    }
+}


### PR DESCRIPTION
## Problem
When microphone disconnects during recording (USB unplugged, Bluetooth disconnects), the app stops and loses the entire recording.

## Solution
- Added `onWarning` callback to `MicrophoneCapture` for graceful disconnection handling
- Recording continues with **system audio only** when mic disconnects  
- Microphone channel padded with silence
- UI shows warning message but recording completes successfully

## Changes
**MicrophoneCapture.swift:**
- Added `onWarning`, `hasWarning`, `clearWarning()` methods
- Changed disconnection from error to warning
- Engine stops but capture object stays alive

**RecordingEngine.swift:**
- Added `onWarning` handler that doesn't stop recording
- Clears warning state at start of recording

## Testing
✅ `swift build` passes
✅ `./scripts/build-app.sh` creates app bundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now receives non-fatal microphone warnings so connection/status issues are shown without interrupting recording.
  * When input is disconnected, recording output is padded with silence to keep streams synchronized and allow recovery.

* **Bug Fixes**
  * Starting a new recording clears previous mic warnings to avoid stale alerts.
  * Warnings are surfaced without overwriting existing errors; recordings no longer abort on mic disconnection.

* **Tests**
  * Added tests covering capture start/stop, disconnection handling, warning callbacks, and repeated cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->