### PR TITLE
Add Settings gear button to toolbar

### DIFF
--- a/EchoNotes/Views/MainWindowView.swift
+++ b/EchoNotes/Views/MainWindowView.swift
@@ -86,6 +86,13 @@ struct MainWindowView: View {
         .pickerStyle(.segmented)
         .frame(width: 200)
 
+        // Settings
+        Button(action: {
+            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        }) {
+            Image(systemName: "gearshape")
+        }
+
         // Record / Stop button
         Button(action: {
             Task {


### PR DESCRIPTION
## Summary

- Add a gear icon button to the main window toolbar that opens the Settings window
- Settings was previously only accessible via Cmd+, with no visible UI affordance

## Test plan

- [ ] Gear icon appears in toolbar between mode picker and Record button
- [ ] Clicking it opens the Settings window
- [ ] Cmd+, still works as before