### PR TITLE
Fix: Refresh sidebar after recording and transcription

### DIFF
--- a/EchoNotes/Views/MainWindowView.swift
+++ b/EchoNotes/Views/MainWindowView.swift
@@ -28,6 +28,18 @@ struct MainWindowView: View {
         .onAppear {
             library.scan()
         }
+        .onChange(of: recorder.isRecording) { _, isRecording in
+            if !isRecording {
+                // Re-scan after recording stops so new entry appears in sidebar
+                library.scan()
+            }
+        }
+        .onChange(of: tm.isTranscribing) { _, isTranscribing in
+            if !isTranscribing {
+                // Re-scan after transcription completes so transcript preview updates
+                library.scan()
+            }
+        }
     }
 
     // MARK: - Detail


### PR DESCRIPTION
## Summary

New recordings weren't appearing in the sidebar until the app was relaunched. The library only scanned once on `.onAppear`.

- Re-scan library when `recorder.isRecording` transitions to `false` (recording stopped)
- Re-scan library when `tm.isTranscribing` transitions to `false` (transcription complete, so preview text updates)

## Test plan

- [ ] Record a meeting — new entry appears in sidebar immediately after stopping
- [ ] Transcribe a recording — sidebar row updates with transcript preview text
- [ ] Existing recordings still load on app launch