### PR TITLE
Fix: Add Transcribe button to detail view for untranscribed recordings

### DIFF
--- a/EchoNotes/Views/RecordingDetailView.swift
+++ b/EchoNotes/Views/RecordingDetailView.swift
@@ -43,13 +43,26 @@ struct RecordingDetailView: View {
                 if let transcript {
                     transcriptSection(transcript)
                 } else {
-                    VStack(spacing: 8) {
+                    VStack(spacing: 12) {
                         Image(systemName: "text.badge.xmark")
                             .font(.title2)
                             .foregroundStyle(.tertiary)
                         Text("No transcript available")
                             .font(.body)
                             .foregroundStyle(.tertiary)
+
+                        Button(action: {
+                            Task { await tm.transcribe(audioURL: entry.url) }
+                        }) {
+                            HStack {
+                                Image(systemName: "text.bubble")
+                                Text("Transcribe")
+                            }
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 24)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(tm.isTranscribing)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 40)
@@ -93,6 +106,12 @@ struct RecordingDetailView: View {
             transcript = entry.loadTranscript()
             if let existing = existingSummary {
                 summary = existing
+            }
+        }
+        .onChange(of: tm.isTranscribing) { _, isTranscribing in
+            if !isTranscribing {
+                // Reload transcript after transcription completes
+                transcript = entry.loadTranscript()
             }
         }
     }


### PR DESCRIPTION
## Summary

After recording, selecting the new entry in the sidebar showed "No transcript available" with no way to transcribe it.

- Add a "Transcribe" button to `RecordingDetailView` when no transcript exists
- Auto-reload transcript in the detail view when transcription completes (via `onChange(of: tm.isTranscribing)`)

## Test plan

- [ ] Record a meeting, stop, select entry in sidebar — Transcribe button appears
- [ ] Click Transcribe — transcription runs, transcript appears automatically when done
- [ ] Entries that already have transcripts still show normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Transcribe button to initiate transcription when transcripts are unavailable
  * Button automatically disables during transcription processing to prevent duplicate requests
  * Transcript content automatically updates upon transcription completion
  * Improved UI spacing in the recording detail view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->