### PR TITLE
Fix: Settings toolbar button not opening Settings window

### DIFF
--- a/EchoNotes/Views/MainWindowView.swift
+++ b/EchoNotes/Views/MainWindowView.swift
@@ -99,9 +99,7 @@ struct MainWindowView: View {
         .frame(width: 200)
 
         // Settings
-        Button(action: {
-            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-        }) {
+        SettingsLink {
             Image(systemName: "gearshape")
         }
 


### PR DESCRIPTION
## Summary

The Settings gear button in the toolbar was non-functional. `NSApp.sendAction(Selector(("showSettingsWindow:")))` silently failed.

- Replace with SwiftUI's native `SettingsLink`, the correct API for macOS 14+

## Test plan

- [ ] Click gear icon in toolbar — Settings window opens
- [ ] Cmd+, still works