### PR TITLE
Add custom OpenAI-compatible endpoint support

### DIFF
--- a/EchoNotes/AI/AIProvider.swift
+++ b/EchoNotes/AI/AIProvider.swift
@@ -6,6 +6,7 @@ enum AIProvider: String, CaseIterable, Codable, Sendable, Identifiable {
     case anthropic = "Anthropic"
     case google = "Google Gemini"
     case ollama = "Ollama (Local)"
+    case custom = "Custom (OpenAI-compatible)"
 
     var id: String { rawValue }
 
@@ -19,12 +20,16 @@ enum AIProvider: String, CaseIterable, Codable, Sendable, Identifiable {
         case .anthropic: return "sk-ant-..."
         case .google: return "AIza..."
         case .ollama: return "No API key needed"
+        case .custom: return "Optional API key"
         }
     }
 
     /// Whether this provider requires an API key.
     var requiresAPIKey: Bool {
-        self != .ollama
+        switch self {
+        case .ollama, .custom: return false
+        default: return true
+        }
     }
 
     /// Default API endpoint.
@@ -34,6 +39,7 @@ enum AIProvider: String, CaseIterable, Codable, Sendable, Identifiable {
         case .anthropic: return "https://api.anthropic.com/v1/messages"
         case .google: return "https://generativelanguage.googleapis.com/v1beta/models"
         case .ollama: return "http://localhost:11434/v1/chat/completions"
+        case .custom: return "http://localhost:8080/v1/chat/completions"
         }
     }
 
@@ -44,6 +50,7 @@ enum AIProvider: String, CaseIterable, Codable, Sendable, Identifiable {
         case .anthropic: return "claude-sonnet-4-5"
         case .google: return "gemini-2.0-flash"
         case .ollama: return "llama3.2"
+        case .custom: return "default"
         }
     }
 
@@ -54,6 +61,7 @@ enum AIProvider: String, CaseIterable, Codable, Sendable, Identifiable {
         case .anthropic: return ["claude-sonnet-4-5", "claude-haiku-3-5"]
         case .google: return ["gemini-2.0-flash", "gemini-2.5-pro"]
         case .ollama: return ["llama3.2", "llama3.1", "mistral", "gemma2"]
+        case .custom: return []
         }
     }
 

--- a/EchoNotes/AI/AIService.swift
+++ b/EchoNotes/AI/AIService.swift
@@ -62,7 +62,7 @@ final class AIService: Sendable {
             return try await summarizeGoogle(transcript: transcript, config: config)
         case .ollama:
             return try await summarizeOllama(transcript: transcript, config: config)
-        case .openai:
+        case .openai, .custom:
             return try await summarizeOpenAICompatible(transcript: transcript, config: config)
         }
     }
@@ -214,7 +214,9 @@ final class AIService: Sendable {
 
         var request = URLRequest(url: config.endpoint)
         request.httpMethod = "POST"
-        request.setValue(config.provider.authHeaderValue(apiKey: config.apiKey), forHTTPHeaderField: config.provider.authHeaderName)
+        if !config.apiKey.isEmpty {
+            request.setValue(config.provider.authHeaderValue(apiKey: config.apiKey), forHTTPHeaderField: config.provider.authHeaderName)
+        }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let accountId = config.chatgptAccountId {
             request.setValue(accountId, forHTTPHeaderField: "chatgpt-account-id")

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -35,6 +35,9 @@ final class TranscriptionManager: ObservableObject {
     private static let providerDefaultsKey = "aiProvider"
     private static let aiModelDefaultsKey = "aiModel"
     private static let whisperModelDefaultsKey = "whisperModel"
+    private static let customEndpointDefaultsKey = "customEndpoint"
+    private static let customModelDefaultsKey = "customModel"
+    private static let customAPIKeyDefaultsKey = "customAPIKey"
 
     /// API key for the selected AI provider.
     @Published var openaiAPIKey: String = UserDefaults.standard.string(forKey: apiKeyDefaultsKey) ?? "" {
@@ -67,6 +70,21 @@ final class TranscriptionManager: ObservableObject {
         didSet { UserDefaults.standard.set(selectedAIModel, forKey: Self.aiModelDefaultsKey) }
     }
 
+    /// Custom OpenAI-compatible endpoint URL.
+    @Published var customEndpoint: String = UserDefaults.standard.string(forKey: customEndpointDefaultsKey) ?? "http://localhost:8080/v1/chat/completions" {
+        didSet { UserDefaults.standard.set(customEndpoint, forKey: Self.customEndpointDefaultsKey) }
+    }
+
+    /// Custom model name for the custom endpoint.
+    @Published var customModel: String = UserDefaults.standard.string(forKey: customModelDefaultsKey) ?? "" {
+        didSet { UserDefaults.standard.set(customModel, forKey: Self.customModelDefaultsKey) }
+    }
+
+    /// Optional API key for the custom endpoint.
+    @Published var customAPIKey: String = UserDefaults.standard.string(forKey: customAPIKeyDefaultsKey) ?? "" {
+        didSet { UserDefaults.standard.set(customAPIKey, forKey: Self.customAPIKeyDefaultsKey) }
+    }
+
     /// OAuth manager for ChatGPT login
     let oauthManager = OAuthManager()
     private var oauthCancellable: AnyCancellable?
@@ -83,6 +101,9 @@ final class TranscriptionManager: ObservableObject {
         // OAuth: either API key or access token via ChatGPT backend
         if selectedProvider == .openai, oauthManager.isAuthenticated {
             return true
+        }
+        if selectedProvider == .custom {
+            return !customEndpoint.isEmpty
         }
         if selectedProvider.requiresAPIKey {
             return !openaiAPIKey.isEmpty
@@ -113,6 +134,15 @@ final class TranscriptionManager: ObservableObject {
                     chatgptAccountId: tokens.accountId
                 )
             }
+        }
+
+        if selectedProvider == .custom {
+            return AIService.Configuration(
+                apiKey: customAPIKey,
+                model: customModel.isEmpty ? "default" : customModel,
+                endpoint: URL(string: customEndpoint) ?? URL(string: "http://localhost:8080/v1/chat/completions")!,
+                provider: .custom
+            )
         }
 
         return AIService.Configuration(

--- a/EchoNotes/Views/DesktopSettingsView.swift
+++ b/EchoNotes/Views/DesktopSettingsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// macOS Settings window with tabs for General, AI, and About.
+/// macOS Settings window with tabs for General, AI, Custom Providers, and About.
 struct DesktopSettingsView: View {
     @EnvironmentObject var recorder: RecordingEngine
     @EnvironmentObject var tm: TranscriptionManager
@@ -11,11 +11,13 @@ struct DesktopSettingsView: View {
             generalTab
                 .tabItem { Label("General", systemImage: "gearshape") }
             aiTab
-                .tabItem { Label("AI", systemImage: "sparkles") }
+                .tabItem { Label("AI Providers", systemImage: "sparkles") }
+            customTab
+                .tabItem { Label("Custom Providers", systemImage: "plus.circle") }
             aboutTab
                 .tabItem { Label("About", systemImage: "info.circle") }
         }
-        .frame(width: 480, height: 400)
+        .frame(width: 560, height: 480)
     }
 
     // MARK: - General
@@ -47,11 +49,65 @@ struct DesktopSettingsView: View {
         .padding()
     }
 
-    // MARK: - AI
+    // MARK: - AI Providers
 
     private var aiTab: some View {
-        SettingsView(tm: tm, onBack: {})
+        SettingsView(tm: tm)
             .padding()
+    }
+
+    // MARK: - Custom Providers
+
+    private var customTab: some View {
+        Form {
+            Section {
+                Text("Connect to any OpenAI-compatible API endpoint (llama.cpp, vLLM, LM Studio, text-generation-webui, etc).")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Endpoint") {
+                TextField("URL", text: $tm.customEndpoint, prompt: Text("http://localhost:8080/v1/chat/completions"))
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            Section("Model") {
+                TextField("Model name", text: $tm.customModel, prompt: Text("e.g. qwen3.5-35b-a3b"))
+                    .textFieldStyle(.roundedBorder)
+                Text("The model name sent in the request body. Check your server's /v1/models endpoint for available models.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("API Key (optional)") {
+                SecureField("API key", text: $tm.customAPIKey, prompt: Text("Leave empty if not required"))
+                    .textFieldStyle(.roundedBorder)
+                Text("Only needed if your server requires authentication.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                HStack {
+                    Button(action: {
+                        tm.selectedProvider = .custom
+                        tm.selectedAIModel = tm.customModel.isEmpty ? "default" : tm.customModel
+                    }) {
+                        Text(tm.selectedProvider == .custom ? "Active" : "Use This Provider")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(tm.customEndpoint.isEmpty || tm.selectedProvider == .custom)
+
+                    if tm.selectedProvider == .custom {
+                        Label("Currently active", systemImage: "checkmark.circle.fill")
+                            .font(.callout)
+                            .foregroundStyle(.green)
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
     }
 
     // MARK: - About


### PR DESCRIPTION
## Summary

Add support for connecting to any OpenAI-compatible API endpoint for AI summarization — llama.cpp, vLLM, LM Studio, text-generation-webui, etc.

- New `Custom (OpenAI-compatible)` provider in `AIProvider`
- New "Custom Providers" tab in Settings with fields for endpoint URL, model name, and optional API key
- Routes through existing `summarizeOpenAICompatible` (OpenAI chat completions format)
- Auth header skipped when API key is empty (for local servers without auth)
- All settings persisted via UserDefaults

### Example: llama.cpp serving Qwen 3.5
- Endpoint: `http://localhost:8080/v1/chat/completions`
- Model: `qwen3.5-35b-a3b`
- API Key: (empty)

## Files changed

| File | Change |
|------|--------|
| `EchoNotes/AI/AIProvider.swift` | Add `.custom` case with defaults |
| `EchoNotes/AI/AIService.swift` | Route `.custom` through OpenAI handler, skip empty auth |
| `EchoNotes/Transcription/TranscriptionManager.swift` | Add `customEndpoint`, `customModel`, `customAPIKey` settings |
| `EchoNotes/Views/DesktopSettingsView.swift` | Add "Custom Providers" tab |

## Test plan

- [ ] Open Settings → Custom Providers tab
- [ ] Enter llama.cpp endpoint and model name
- [ ] Click "Use This Provider" — shows as active
- [ ] Generate a summary — request goes to custom endpoint
- [ ] Settings persist after app restart
- [ ] Built-in providers (OpenAI, Anthropic, etc) still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom OpenAI-compatible AI providers, enabling seamless integration with self-hosted or third-party AI services
  * New "Custom Providers" settings tab with dedicated fields to configure custom endpoint, model, and API key settings
  * Enhanced AI provider management with additional configuration options and improved user control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->