### PR TITLE
Fix: Show settings inline in detail area instead of separate window

### DIFF
--- a/EchoNotes/App/EchoNotesApp.swift
+++ b/EchoNotes/App/EchoNotesApp.swift
@@ -14,12 +14,5 @@ struct EchoNotesApp: App {
                 .environmentObject(appDelegate.library)
         }
         .defaultSize(width: 960, height: 640)
-
-        Settings {
-            SettingsSidebarView()
-                .environmentObject(appDelegate.recorder)
-                .environmentObject(appDelegate.recorder.transcriptionManager)
-                .environmentObject(appDelegate.recorder.transcriptionManager.modelManager)
-        }
     }
 }

--- a/EchoNotes/Views/DesktopSettingsView.swift
+++ b/EchoNotes/Views/DesktopSettingsView.swift
@@ -17,7 +17,7 @@ struct DesktopSettingsView: View {
             aboutTab
                 .tabItem { Label("About", systemImage: "info.circle") }
         }
-        .frame(width: 560, height: 480)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - General

--- a/EchoNotes/Views/MainWindowView.swift
+++ b/EchoNotes/Views/MainWindowView.swift
@@ -8,6 +8,7 @@ struct MainWindowView: View {
     @EnvironmentObject var library: RecordingLibrary
 
     @State private var selectedEntryID: URL?
+    @State private var showingSettings = false
 
     private var selectedEntry: RecordingEntry? {
         guard let id = selectedEntryID else { return nil }
@@ -46,7 +47,9 @@ struct MainWindowView: View {
 
     @ViewBuilder
     private var detailContent: some View {
-        if recorder.isRecording || tm.isTranscribing || modelManager.isDownloading || modelManager.isLoading {
+        if showingSettings {
+            DesktopSettingsView()
+        } else if recorder.isRecording || tm.isTranscribing || modelManager.isDownloading || modelManager.isLoading {
             ActiveRecordingView()
         } else if let entry = selectedEntry {
             RecordingDetailView(entry: entry)
@@ -99,9 +102,10 @@ struct MainWindowView: View {
         .frame(width: 200)
 
         // Settings
-        SettingsLink {
+        Button(action: { showingSettings.toggle() }) {
             Image(systemName: "gearshape")
         }
+        .help(showingSettings ? "Close Settings" : "Settings")
 
         // Record / Stop button
         Button(action: {


### PR DESCRIPTION
## Summary

The gear button was opening settings in a separate macOS window via `SettingsLink`. Now shows settings inline in the main window's detail area.

- Replace `SettingsLink` with a toggle button that shows `DesktopSettingsView` in the detail pane
- Remove the separate `Settings` scene from `EchoNotesApp`
- Remove fixed frame from `DesktopSettingsView` so it fills the detail area

## Test plan

- [ ] Click gear icon — settings appear in the detail area
- [ ] Click gear icon again — settings dismiss, returns to previous content
- [ ] Select a recording while settings are open — shows recording detail
- [ ] No separate settings window opens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings now display as an inline panel within the main window with a toggle button in the toolbar.

* **Improvements**
  * Settings panel expands to fill available space for better usability and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->