### PR TITLE
Fix: Improve llama.cpp/local model compatibility

### DIFF
--- a/EchoNotes/AI/AIService.swift
+++ b/EchoNotes/AI/AIService.swift
@@ -201,15 +201,16 @@ final class AIService: Sendable {
 
     private func summarizeOpenAICompatible(transcript: String, config: Configuration) async throws -> MeetingSummary {
         let prompt = summaryPrompt(transcript: transcript)
+        let isLocal = config.provider == .custom || config.provider == .ollama
 
-        var requestBody: [String: Any] = [
+        let requestBody: [String: Any] = [
             "model": config.model,
             "messages": [
-                ["role": "system", "content": "You are a meeting assistant. Extract structured summaries from transcripts. Respond only with valid JSON."],
+                ["role": "system", "content": "You are a meeting assistant. Extract structured summaries from transcripts. Respond only with valid JSON. Do not include any explanation or thinking, just the JSON object."],
                 ["role": "user", "content": prompt]
             ],
             "temperature": 0.3,
-            "max_tokens": 2000
+            "max_tokens": isLocal ? 4096 : 2000
         ]
 
         var request = URLRequest(url: config.endpoint)
@@ -222,7 +223,8 @@ final class AIService: Sendable {
             request.setValue(accountId, forHTTPHeaderField: "chatgpt-account-id")
         }
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
-        request.timeoutInterval = 120
+        // Local models need more time — a 35B model on a long transcript can take minutes
+        request.timeoutInterval = isLocal ? 300 : 120
 
         let (data, response) = try await URLSession.shared.data(for: request)
 


### PR DESCRIPTION
## Summary
- Increase timeout from 120s to 300s for local providers (custom/ollama) — large models on long transcripts can take minutes
- Increase max_tokens from 2000 to 4096 for local providers to avoid truncated JSON output
- Update system prompt to explicitly discourage thinking/explanation output (helps with reasoning models like Qwen that emit `<think>` blocks)

## Context
When using llama.cpp serving Qwen 35B-A3B, the previous settings could cause:
- Timeouts on longer transcripts
- Truncated JSON responses due to low max_tokens
- Extra reasoning output mixed into the response

These changes complement PR #147 (robust JSON parsing) by also reducing the likelihood of malformed responses from local models.

## Test plan
- [ ] Run llama.cpp with a local model and generate an AI summary
- [ ] Verify summary completes without timeout for longer transcripts
- [ ] Verify JSON response is not truncated
- [ ] Verify cloud providers (OpenAI, Anthropic) still use original 120s/2000 limits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced support for local AI models with optimized request handling and timeout configuration.
  * Improved AI response formatting for better consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->