### PR TITLE
Add knowledge base context for AI summaries

### DIFF
--- a/EchoNotes/AI/AIService.swift
+++ b/EchoNotes/AI/AIService.swift
@@ -49,21 +49,21 @@ final class AIService: Sendable {
     }
 
     /// Summarize a transcript using the configured AI provider.
-    func summarize(transcript: String, config: Configuration) async throws -> MeetingSummary {
+    func summarize(transcript: String, config: Configuration, knowledgeBaseContext: String? = nil) async throws -> MeetingSummary {
         // Use ChatGPT backend Responses API when we have an account ID but no API key
         if config.chatgptAccountId != nil {
-            return try await summarizeChatGPTBackend(transcript: transcript, config: config)
+            return try await summarizeChatGPTBackend(transcript: transcript, config: config, knowledgeBaseContext: knowledgeBaseContext)
         }
 
         switch config.provider {
         case .anthropic:
-            return try await summarizeAnthropic(transcript: transcript, config: config)
+            return try await summarizeAnthropic(transcript: transcript, config: config, knowledgeBaseContext: knowledgeBaseContext)
         case .google:
-            return try await summarizeGoogle(transcript: transcript, config: config)
+            return try await summarizeGoogle(transcript: transcript, config: config, knowledgeBaseContext: knowledgeBaseContext)
         case .ollama:
-            return try await summarizeOllama(transcript: transcript, config: config)
+            return try await summarizeOllama(transcript: transcript, config: config, knowledgeBaseContext: knowledgeBaseContext)
         case .openai, .custom:
-            return try await summarizeOpenAICompatible(transcript: transcript, config: config)
+            return try await summarizeOpenAICompatible(transcript: transcript, config: config, knowledgeBaseContext: knowledgeBaseContext)
         }
     }
 
@@ -72,8 +72,8 @@ final class AIService: Sendable {
     /// Use the ChatGPT backend Responses API with OAuth access token.
     /// Same approach as Codex CLI: Bearer access_token + chatgpt-account-id header.
     /// The Codex backend requires stream: true, so we collect SSE events.
-    private func summarizeChatGPTBackend(transcript: String, config: Configuration) async throws -> MeetingSummary {
-        let prompt = summaryPrompt(transcript: transcript)
+    private func summarizeChatGPTBackend(transcript: String, config: Configuration, knowledgeBaseContext: String? = nil) async throws -> MeetingSummary {
+        let prompt = summaryPrompt(transcript: transcript, knowledgeBaseContext: knowledgeBaseContext)
         let systemPrompt = "You are a meeting assistant. Extract structured summaries from transcripts. Respond only with valid JSON."
 
         let requestBody: [String: Any] = [
@@ -180,8 +180,8 @@ final class AIService: Sendable {
 
     // MARK: - OpenAI-compatible (OpenAI)
 
-    private func summarizeOpenAICompatible(transcript: String, config: Configuration) async throws -> MeetingSummary {
-        let prompt = summaryPrompt(transcript: transcript)
+    private func summarizeOpenAICompatible(transcript: String, config: Configuration, knowledgeBaseContext: String? = nil) async throws -> MeetingSummary {
+        let prompt = summaryPrompt(transcript: transcript, knowledgeBaseContext: knowledgeBaseContext)
         let isLocal = config.provider == .custom || config.provider == .ollama
 
         let requestBody: [String: Any] = [
@@ -222,8 +222,8 @@ final class AIService: Sendable {
 
     // MARK: - Ollama
 
-    private func summarizeOllama(transcript: String, config: Configuration) async throws -> MeetingSummary {
-        let prompt = summaryPrompt(transcript: transcript)
+    private func summarizeOllama(transcript: String, config: Configuration, knowledgeBaseContext: String? = nil) async throws -> MeetingSummary {
+        let prompt = summaryPrompt(transcript: transcript, knowledgeBaseContext: knowledgeBaseContext)
 
         let requestBody: [String: Any] = [
             "model": config.model,
@@ -255,8 +255,8 @@ final class AIService: Sendable {
 
     // MARK: - Anthropic
 
-    private func summarizeAnthropic(transcript: String, config: Configuration) async throws -> MeetingSummary {
-        let prompt = summaryPrompt(transcript: transcript)
+    private func summarizeAnthropic(transcript: String, config: Configuration, knowledgeBaseContext: String? = nil) async throws -> MeetingSummary {
+        let prompt = summaryPrompt(transcript: transcript, knowledgeBaseContext: knowledgeBaseContext)
 
         let requestBody: [String: Any] = [
             "model": config.model,
@@ -290,8 +290,8 @@ final class AIService: Sendable {
 
     // MARK: - Google Gemini
 
-    private func summarizeGoogle(transcript: String, config: Configuration) async throws -> MeetingSummary {
-        let prompt = summaryPrompt(transcript: transcript)
+    private func summarizeGoogle(transcript: String, config: Configuration, knowledgeBaseContext: String? = nil) async throws -> MeetingSummary {
+        let prompt = summaryPrompt(transcript: transcript, knowledgeBaseContext: knowledgeBaseContext)
 
         let endpointURL = URL(string: "\(config.provider.defaultEndpoint)/\(config.model):generateContent?key=\(config.apiKey)")!
 
@@ -327,8 +327,8 @@ final class AIService: Sendable {
 
     // MARK: - Shared Prompt
 
-    private func summaryPrompt(transcript: String) -> String {
-        """
+    private func summaryPrompt(transcript: String, knowledgeBaseContext: String? = nil) -> String {
+        var prompt = """
         Analyze this meeting transcript and provide a structured summary.
 
         Respond ONLY with valid JSON in this exact format:
@@ -340,10 +340,24 @@ final class AIService: Sendable {
         }
 
         If a section has no items, use an empty array.
+        """
 
-        TRANSCRIPT:
+        if let context = knowledgeBaseContext {
+            prompt += """
+
+            \nUse the following project knowledge base for context. Reference correct terminology, people, and prior decisions where relevant:
+
+            \(context)
+            """
+        }
+
+        prompt += """
+
+        \nTRANSCRIPT:
         \(transcript)
         """
+
+        return prompt
     }
 
     /// Parse OpenAI chat completion response into MeetingSummary.

--- a/EchoNotes/AI/KnowledgeBaseService.swift
+++ b/EchoNotes/AI/KnowledgeBaseService.swift
@@ -1,0 +1,163 @@
+import Foundation
+import os
+
+/// Scans a folder of markdown files and assembles relevant context for AI summarization.
+/// Designed for Obsidian vaults but works with any folder of .md files.
+final class KnowledgeBaseService: Sendable {
+    private let logger = Logger(subsystem: "com.echonotes", category: "KnowledgeBase")
+
+    /// Maximum characters of assembled context (~2000 tokens at ~4 chars/token).
+    private let maxContextChars = 8000
+
+    /// Build context from a knowledge base folder, ranked by relevance to the transcript.
+    func buildContext(vaultPath: String, transcript: String) -> String? {
+        let vaultURL = URL(fileURLWithPath: (vaultPath as NSString).expandingTildeInPath)
+
+        guard FileManager.default.fileExists(atPath: vaultURL.path) else {
+            logger.warning("Knowledge base path does not exist: \(vaultPath)")
+            return nil
+        }
+
+        // Collect all .md files (skip .obsidian)
+        let mdFiles = collectMarkdownFiles(in: vaultURL)
+        guard !mdFiles.isEmpty else { return nil }
+
+        // Extract keywords from transcript
+        let keywords = extractKeywords(from: transcript)
+        guard !keywords.isEmpty else { return nil }
+
+        // Score and rank files
+        var scored: [(url: URL, score: Int, content: String)] = []
+        for fileURL in mdFiles {
+            guard let content = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
+            let score = scoreFile(url: fileURL, content: content, keywords: keywords, vaultURL: vaultURL)
+            if score > 0 {
+                scored.append((fileURL, score, content))
+            }
+        }
+
+        scored.sort { $0.score > $1.score }
+
+        // Assemble context within budget
+        var context = ""
+        var charBudget = maxContextChars
+
+        // Always try to include CLAUDE.md or Home.md first (project overview)
+        let overviewFiles = scored.filter { url, _, _ in
+            let name = url.lastPathComponent.lowercased()
+            return name == "claude.md" || name == "home.md"
+        }
+        let rest = scored.filter { url, _, _ in
+            let name = url.lastPathComponent.lowercased()
+            return name != "claude.md" && name != "home.md"
+        }
+
+        let orderedFiles = overviewFiles + rest
+
+        for (fileURL, _, content) in orderedFiles {
+            let relativePath = fileURL.path.replacingOccurrences(of: vaultURL.path + "/", with: "")
+            let header = "### \(relativePath)\n"
+            // Truncate individual files to keep things balanced
+            let maxPerFile = min(2000, charBudget)
+            let truncated = content.count > maxPerFile
+                ? String(content.prefix(maxPerFile)) + "\n[...truncated]"
+                : content
+            let entry = header + truncated + "\n\n"
+
+            if entry.count > charBudget { break }
+            context += entry
+            charBudget -= entry.count
+            if charBudget <= 0 { break }
+        }
+
+        guard !context.isEmpty else { return nil }
+
+        logger.info("Built knowledge base context: \(context.count) chars from \(min(orderedFiles.count, 10)) files")
+        return context
+    }
+
+    // MARK: - Private
+
+    private func collectMarkdownFiles(in directory: URL) -> [URL] {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        var files: [URL] = []
+        for case let fileURL as URL in enumerator {
+            if fileURL.pathExtension.lowercased() == "md" {
+                files.append(fileURL)
+            }
+        }
+        return files
+    }
+
+    /// Extract meaningful keywords from the transcript for matching.
+    private func extractKeywords(from transcript: String) -> Set<String> {
+        // Split into words, lowercase, filter short/common words
+        let stopWords: Set<String> = [
+            "the", "and", "for", "that", "this", "with", "from", "have", "been",
+            "will", "are", "was", "were", "has", "had", "not", "but", "they",
+            "you", "your", "our", "can", "would", "could", "should", "about",
+            "what", "when", "where", "how", "who", "which", "there", "their",
+            "then", "than", "also", "just", "like", "into", "over", "some",
+            "yeah", "okay", "right", "going", "think", "know", "want", "need",
+            "thing", "things", "really", "actually", "basically", "gonna",
+            "got", "get", "one", "two", "three", "it's", "i'm", "we're",
+            "don't", "didn't", "that's", "let's", "it'll", "we'll", "i'll",
+            "speaker", "unknown"
+        ]
+
+        let words = transcript.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { $0.count >= 3 && !stopWords.contains($0) }
+
+        // Count frequency and take top keywords
+        var freq: [String: Int] = [:]
+        for word in words { freq[word, default: 0] += 1 }
+
+        let topKeywords = freq.sorted { $0.value > $1.value }
+            .prefix(50)
+            .map { $0.key }
+
+        return Set(topKeywords)
+    }
+
+    /// Score a file by keyword overlap with the transcript.
+    private func scoreFile(url: URL, content: String, keywords: Set<String>, vaultURL: URL) -> Int {
+        let lowerContent = content.lowercased()
+        let fileName = url.deletingPathExtension().lastPathComponent.lowercased()
+        let relativePath = url.path.replacingOccurrences(of: vaultURL.path + "/", with: "").lowercased()
+
+        var score = 0
+
+        // Keyword matches in content
+        for keyword in keywords {
+            if lowerContent.contains(keyword) {
+                score += 1
+            }
+        }
+
+        // Keyword matches in filename (weighted higher)
+        for keyword in keywords {
+            if fileName.contains(keyword) {
+                score += 5
+            }
+        }
+
+        // Boost overview/hub files
+        if fileName == "claude" || fileName == "home" { score += 10 }
+        if fileName.contains("hub") || fileName.contains("overview") { score += 3 }
+
+        // Boost meetings folder (relevant past context)
+        if relativePath.hasPrefix("meetings/") { score += 2 }
+
+        // Boost specs (technical context)
+        if relativePath.hasPrefix("specs/") { score += 1 }
+
+        return score
+    }
+}

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -38,6 +38,8 @@ final class TranscriptionManager: ObservableObject {
     private static let customEndpointDefaultsKey = "customEndpoint"
     private static let customModelDefaultsKey = "customModel"
     private static let customAPIKeyDefaultsKey = "customAPIKey"
+    private static let knowledgeBasePathDefaultsKey = "knowledgeBasePath"
+    private static let useKnowledgeBaseDefaultsKey = "useKnowledgeBase"
 
     /// API key for the selected AI provider.
     @Published var openaiAPIKey: String = UserDefaults.standard.string(forKey: apiKeyDefaultsKey) ?? "" {
@@ -83,6 +85,16 @@ final class TranscriptionManager: ObservableObject {
     /// Optional API key for the custom endpoint.
     @Published var customAPIKey: String = UserDefaults.standard.string(forKey: customAPIKeyDefaultsKey) ?? "" {
         didSet { UserDefaults.standard.set(customAPIKey, forKey: Self.customAPIKeyDefaultsKey) }
+    }
+
+    /// Path to a knowledge base folder (e.g., Obsidian vault) for contextual summaries.
+    @Published var knowledgeBasePath: String = UserDefaults.standard.string(forKey: knowledgeBasePathDefaultsKey) ?? "" {
+        didSet { UserDefaults.standard.set(knowledgeBasePath, forKey: Self.knowledgeBasePathDefaultsKey) }
+    }
+
+    /// Whether to include knowledge base context in AI summaries.
+    @Published var useKnowledgeBase: Bool = UserDefaults.standard.bool(forKey: useKnowledgeBaseDefaultsKey) {
+        didSet { UserDefaults.standard.set(useKnowledgeBase, forKey: Self.useKnowledgeBaseDefaultsKey) }
     }
 
     /// OAuth manager for ChatGPT login
@@ -275,7 +287,15 @@ final class TranscriptionManager: ObservableObject {
         do {
             let config = aiConfiguration()
             let service = AIService()
-            let result = try await service.summarize(transcript: transcript.toPlainText(), config: config)
+
+            // Build knowledge base context if enabled
+            var kbContext: String?
+            if useKnowledgeBase, !knowledgeBasePath.isEmpty {
+                let kbService = KnowledgeBaseService()
+                kbContext = kbService.buildContext(vaultPath: knowledgeBasePath, transcript: transcript.toPlainText())
+            }
+
+            let result = try await service.summarize(transcript: transcript.toPlainText(), config: config, knowledgeBaseContext: kbContext)
 
             // Save as .md alongside the recording
             let mdURL = transcript.recordingURL.deletingPathExtension().appendingPathExtension("md")

--- a/EchoNotes/Views/DesktopSettingsView.swift
+++ b/EchoNotes/Views/DesktopSettingsView.swift
@@ -17,6 +17,8 @@ struct DesktopSettingsView: View {
                 .tabItem { Label("AI Providers", systemImage: "sparkles") }
             customTab
                 .tabItem { Label("Custom Providers", systemImage: "plus.circle") }
+            knowledgeBaseTab
+                .tabItem { Label("Knowledge Base", systemImage: "book.closed") }
             aboutTab
                 .tabItem { Label("About", systemImage: "info.circle") }
         }
@@ -134,6 +136,88 @@ struct DesktopSettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+    }
+
+    // MARK: - Knowledge Base
+
+    @State private var knowledgeBaseFileCount: Int?
+
+    private var knowledgeBaseTab: some View {
+        Form {
+            Section {
+                Text("Point to a folder of markdown files (e.g., an Obsidian vault) to give AI summaries contextual knowledge about your project, team, and prior decisions.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Folder Path") {
+                HStack {
+                    TextField("Path", text: $tm.knowledgeBasePath, prompt: Text("~/Documents/my-vault"))
+                        .textFieldStyle(.roundedBorder)
+                    Button("Browse...") {
+                        let panel = NSOpenPanel()
+                        panel.canChooseFiles = false
+                        panel.canChooseDirectories = true
+                        panel.allowsMultipleSelection = false
+                        if panel.runModal() == .OK, let url = panel.url {
+                            tm.knowledgeBasePath = url.path
+                            scanKnowledgeBase()
+                        }
+                    }
+                }
+
+                if let count = knowledgeBaseFileCount {
+                    Label("\(count) markdown files found", systemImage: "doc.text")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                } else if !tm.knowledgeBasePath.isEmpty {
+                    Label("Folder not found", systemImage: "exclamationmark.triangle")
+                        .font(.callout)
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            Section {
+                Toggle("Include knowledge base context in AI summaries", isOn: $tm.useKnowledgeBase)
+                    .disabled(tm.knowledgeBasePath.isEmpty)
+
+                if tm.useKnowledgeBase && !tm.knowledgeBasePath.isEmpty {
+                    Text("When generating a summary, EchoNotes will auto-discover relevant files from your knowledge base and include them as context for the AI.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+        .onAppear { scanKnowledgeBase() }
+    }
+
+    private func scanKnowledgeBase() {
+        guard !tm.knowledgeBasePath.isEmpty else {
+            knowledgeBaseFileCount = nil
+            return
+        }
+        let path = (tm.knowledgeBasePath as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: path)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            knowledgeBaseFileCount = nil
+            return
+        }
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: url,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            knowledgeBaseFileCount = nil
+            return
+        }
+        var count = 0
+        for case let fileURL as URL in enumerator {
+            if fileURL.pathExtension.lowercased() == "md" { count += 1 }
+        }
+        knowledgeBaseFileCount = count
     }
 
     // MARK: - About


### PR DESCRIPTION
## Summary
- Add support for pointing EchoNotes at a folder of markdown files (e.g., an Obsidian vault) to enrich AI summaries with project context
- New `KnowledgeBaseService` auto-discovers relevant files by extracting keywords from the transcript and ranking vault files by relevance
- New "Knowledge Base" tab in settings with a folder browser, file count indicator, and on/off toggle
- Context is injected into the summarization prompt for all AI providers (OpenAI, Anthropic, Google, Ollama, custom)

## How it works
1. User sets a knowledge base folder path (e.g., `~/code/OKU_MONEY/obsidian/oku-money-vault`)
2. Enables the "Include knowledge base context" toggle
3. When generating a summary, `KnowledgeBaseService`:
   - Scans all `.md` files in the folder (skips hidden files)
   - Extracts top 50 keywords from the transcript by frequency
   - Scores each vault file by keyword matches in content and filename
   - Boosts overview files (CLAUDE.md, Home.md), hub files, meetings, and specs
   - Assembles top-ranked files into a context block (~8K chars / ~2K tokens)
4. Context is prepended to the transcript in the AI prompt with: "Use the following project knowledge base for context. Reference correct terminology, people, and prior decisions where relevant."

## Files changed
| File | Change |
|------|--------|
| `EchoNotes/AI/KnowledgeBaseService.swift` | **New** — vault scanning, keyword extraction, relevance ranking |
| `EchoNotes/AI/AIService.swift` | Thread `knowledgeBaseContext` through all provider methods and into prompt |
| `EchoNotes/Transcription/TranscriptionManager.swift` | Add `knowledgeBasePath` and `useKnowledgeBase` settings |
| `EchoNotes/Views/DesktopSettingsView.swift` | Add "Knowledge Base" settings tab with folder picker |

## Test plan
- [ ] Open Settings > Knowledge Base tab
- [ ] Click "Browse..." and select an Obsidian vault folder
- [ ] Verify file count shows correctly
- [ ] Enable the toggle and generate an AI summary
- [ ] Verify the summary uses correct project terminology from the vault
- [ ] Disable the toggle and verify summaries work normally without context
- [ ] Test with empty/invalid path — should gracefully show "Folder not found"