### PR TITLE
Add in-app debug console (Developer tab)

### DIFF
--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -19,6 +19,7 @@ import os
 @MainActor
 final class RecordingEngine: ObservableObject {
     private let logger = Logger(subsystem: "com.echonotes", category: "RecordingEngine")
+    private var debugLog: DebugLogger { DebugLogger.shared }
     @Published var isRecording = false
     @Published var duration: TimeInterval = 0
     @Published var micLevel: Float = 0
@@ -208,6 +209,7 @@ final class RecordingEngine: ObservableObject {
             recordingStartTime = Date()
             isRecording = true
             logger.info("Recording started: \(fileURL.lastPathComponent)")
+            debugLog.info("Recording started: \(fileURL.lastPathComponent)", category: "Recording")
 
             // Duration timer
             durationTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
@@ -245,6 +247,7 @@ final class RecordingEngine: ObservableObject {
         if let url {
             lastRecordingURL = url
             logger.info("Recording stopped: \(url.lastPathComponent), duration: \(String(format: "%.1f", recordedDuration))s")
+            debugLog.info("Recording stopped: \(url.lastPathComponent) (\(String(format: "%.1f", recordedDuration))s)", category: "Recording")
 
             if transcriptionMode == .live {
                 // Finalize live transcription — flush remaining chunks

--- a/EchoNotes/Models/DebugLogger.swift
+++ b/EchoNotes/Models/DebugLogger.swift
@@ -1,0 +1,68 @@
+import Foundation
+import os
+
+/// In-app debug log that captures entries for display in the UI.
+/// Wraps os.Logger so entries go to both Console.app and the in-app debug console.
+@MainActor
+final class DebugLogger: ObservableObject {
+    static let shared = DebugLogger()
+
+    struct Entry: Identifiable {
+        let id = UUID()
+        let timestamp: Date
+        let category: String
+        let level: Level
+        let message: String
+
+        enum Level: String {
+            case info = "INFO"
+            case warning = "WARN"
+            case error = "ERROR"
+            case debug = "DEBUG"
+        }
+    }
+
+    @Published private(set) var entries: [Entry] = []
+
+    /// Maximum entries to keep in memory.
+    private let maxEntries = 500
+
+    private init() {}
+
+    func log(_ message: String, category: String, level: Entry.Level = .info) {
+        let entry = Entry(timestamp: Date(), category: category, level: level, message: message)
+        entries.append(entry)
+        if entries.count > maxEntries {
+            entries.removeFirst(entries.count - maxEntries)
+        }
+
+        // Also log to os.Logger
+        let logger = Logger(subsystem: "com.echonotes", category: category)
+        switch level {
+        case .info: logger.info("\(message)")
+        case .warning: logger.warning("\(message)")
+        case .error: logger.error("\(message)")
+        case .debug: logger.debug("\(message)")
+        }
+    }
+
+    func info(_ message: String, category: String) {
+        log(message, category: category, level: .info)
+    }
+
+    func warning(_ message: String, category: String) {
+        log(message, category: category, level: .warning)
+    }
+
+    func error(_ message: String, category: String) {
+        log(message, category: category, level: .error)
+    }
+
+    func debug(_ message: String, category: String) {
+        log(message, category: category, level: .debug)
+    }
+
+    func clear() {
+        entries.removeAll()
+    }
+}

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -20,6 +20,7 @@ enum TranscriptionMode: String, CaseIterable {
 @MainActor
 final class TranscriptionManager: ObservableObject {
     private let logger = Logger(subsystem: "com.echonotes", category: "TranscriptionManager")
+    private var debugLog: DebugLogger { DebugLogger.shared }
     @Published var isTranscribing = false
     @Published var progress: Double = 0
     @Published var transcript: Transcript?
@@ -229,8 +230,10 @@ final class TranscriptionManager: ObservableObject {
         let task = Task {
             do {
                 logger.info("Starting transcription for \(audioURL.lastPathComponent)")
+                await MainActor.run { self.debugLog.info("Starting transcription: \(audioURL.lastPathComponent)", category: "Transcription") }
                 let engine = try await modelManager.ensureEngine(for: selectedModel)
                 logger.info("Engine ready, transcribing...")
+                await MainActor.run { self.debugLog.info("Whisper engine ready (model: \(self.selectedModel.rawValue)), transcribing...", category: "Transcription") }
                 whisperEngine = engine
 
                 try Task.checkCancellation()
@@ -259,6 +262,7 @@ final class TranscriptionManager: ObservableObject {
             } catch {
                 logger.error("Transcription failed: \(error.localizedDescription)")
                 await MainActor.run {
+                    self.debugLog.error("Transcription failed: \(error.localizedDescription)", category: "Transcription")
                     self.error = error.localizedDescription
                 }
             }
@@ -287,12 +291,19 @@ final class TranscriptionManager: ObservableObject {
         do {
             let config = aiConfiguration()
             let service = AIService()
+            debugLog.info("Summarizing with \(config.provider.rawValue) (\(config.model))", category: "AI")
 
             // Build knowledge base context if enabled
             var kbContext: String?
             if useKnowledgeBase, !knowledgeBasePath.isEmpty {
+                debugLog.info("Loading knowledge base from: \(knowledgeBasePath)", category: "KnowledgeBase")
                 let kbService = KnowledgeBaseService()
                 kbContext = kbService.buildContext(vaultPath: knowledgeBasePath, transcript: transcript.toPlainText())
+                if let ctx = kbContext {
+                    debugLog.info("Injecting \(ctx.count) chars of vault context into prompt", category: "KnowledgeBase")
+                } else {
+                    debugLog.warning("No relevant context found in vault", category: "KnowledgeBase")
+                }
             }
 
             let result = try await service.summarize(transcript: transcript.toPlainText(), config: config, knowledgeBaseContext: kbContext)
@@ -301,8 +312,10 @@ final class TranscriptionManager: ObservableObject {
             let mdURL = transcript.recordingURL.deletingPathExtension().appendingPathExtension("md")
             try result.toMarkdown().write(to: mdURL, atomically: true, encoding: .utf8)
 
+            debugLog.info("Summary generated successfully", category: "AI")
             self.summary = result
         } catch {
+            debugLog.error("Summary failed: \(error.localizedDescription)", category: "AI")
             self.error = error.localizedDescription
         }
 

--- a/EchoNotes/Views/DesktopSettingsView.swift
+++ b/EchoNotes/Views/DesktopSettingsView.swift
@@ -19,6 +19,8 @@ struct DesktopSettingsView: View {
                 .tabItem { Label("Custom Providers", systemImage: "plus.circle") }
             knowledgeBaseTab
                 .tabItem { Label("Knowledge Base", systemImage: "book.closed") }
+            developerTab
+                .tabItem { Label("Developer", systemImage: "chevron.left.forwardslash.chevron.right") }
             aboutTab
                 .tabItem { Label("About", systemImage: "info.circle") }
         }
@@ -218,6 +220,104 @@ struct DesktopSettingsView: View {
             if fileURL.pathExtension.lowercased() == "md" { count += 1 }
         }
         knowledgeBaseFileCount = count
+    }
+
+    // MARK: - Developer
+
+    @ObservedObject private var debugLog = DebugLogger.shared
+
+    private var developerTab: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Debug Console")
+                    .font(.headline)
+                Spacer()
+                Text("\(debugLog.entries.count) entries")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Button("Clear") { debugLog.clear() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            if debugLog.entries.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "terminal")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.secondary)
+                    Text("No log entries yet")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Text("Logs appear here as you record, transcribe, and generate summaries.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 1) {
+                            ForEach(debugLog.entries) { entry in
+                                debugLogRow(entry)
+                                    .id(entry.id)
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                    }
+                    .onChange(of: debugLog.entries.count) { _, _ in
+                        if let last = debugLog.entries.last {
+                            proxy.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+        }
+        .background(Color(nsColor: .textBackgroundColor).opacity(0.5))
+    }
+
+    private static let logTimeFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
+
+    private func debugLogRow(_ entry: DebugLogger.Entry) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Text(Self.logTimeFmt.string(from: entry.timestamp))
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            Text(entry.level.rawValue)
+                .font(.system(.caption2, design: .monospaced).bold())
+                .foregroundStyle(logLevelColor(entry.level))
+                .frame(width: 36, alignment: .leading)
+
+            Text(entry.category)
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.purple)
+                .frame(width: 100, alignment: .leading)
+
+            Text(entry.message)
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func logLevelColor(_ level: DebugLogger.Entry.Level) -> Color {
+        switch level {
+        case .info: return .green
+        case .warning: return .orange
+        case .error: return .red
+        case .debug: return .secondary
+        }
     }
 
     // MARK: - About


### PR DESCRIPTION
## Summary
- New **Developer** tab in Settings with a real-time debug console
- Shows timestamped, color-coded log entries (INFO green, WARN orange, ERROR red)
- Monospaced font, category labels, auto-scroll, max 500 entries, Clear button
- Logs recording start/stop, transcription events, AI summarization, and knowledge base context injection
- No more switching to Console.app to debug

## Events logged
| Category | Events |
|----------|--------|
| Recording | Start, stop (with filename and duration) |
| Transcription | Start, engine ready, errors |
| AI | Provider/model used, summary success/failure |
| KnowledgeBase | Vault loading, context size injected, warnings |

## Test plan
- [ ] Open Settings > Developer tab
- [ ] Verify empty state shows "No log entries yet"
- [ ] Start and stop a recording — verify log entries appear
- [ ] Transcribe a recording — verify transcription logs
- [ ] Generate an AI summary — verify AI and KnowledgeBase logs
- [ ] Click Clear — verify entries are removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Developer tab in Settings with a comprehensive Debug Console. Users can view detailed application logs with timestamps, category labels, and color-coded severity indicators (info, warning, error, debug). The console includes a Clear button to manage log history and automatically scrolls to display the most recent entries for easier monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->