### PR TITLE
Fix: Settings as right-side panel, not full overlay

### DIFF
--- a/EchoNotes/Views/MainWindowView.swift
+++ b/EchoNotes/Views/MainWindowView.swift
@@ -19,7 +19,17 @@ struct MainWindowView: View {
         NavigationSplitView {
             SidebarView(selectedEntryID: $selectedEntryID)
         } detail: {
-            detailContent
+            HStack(spacing: 0) {
+                detailContent
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                if showingSettings {
+                    Divider()
+                    DesktopSettingsView()
+                        .frame(width: 520)
+                        .transition(.move(edge: .trailing))
+                }
+            }
         }
         .toolbar {
             ToolbarItemGroup(placement: .automatic) {
@@ -47,9 +57,7 @@ struct MainWindowView: View {
 
     @ViewBuilder
     private var detailContent: some View {
-        if showingSettings {
-            DesktopSettingsView()
-        } else if recorder.isRecording || tm.isTranscribing || modelManager.isDownloading || modelManager.isLoading {
+        if recorder.isRecording || tm.isTranscribing || modelManager.isDownloading || modelManager.isLoading {
             ActiveRecordingView()
         } else if let entry = selectedEntry {
             RecordingDetailView(entry: entry)
@@ -102,7 +110,7 @@ struct MainWindowView: View {
         .frame(width: 200)
 
         // Settings
-        Button(action: { showingSettings.toggle() }) {
+        Button(action: { withAnimation(.easeInOut(duration: 0.2)) { showingSettings.toggle() } }) {
             Image(systemName: "gearshape")
         }
         .help(showingSettings ? "Close Settings" : "Settings")

--- a/EchoNotes/Views/SettingsView.swift
+++ b/EchoNotes/Views/SettingsView.swift
@@ -130,7 +130,7 @@ struct SettingsView: View {
                         Text(provider.displayName).tag(provider)
                     }
                 }
-                .pickerStyle(.segmented)
+                .pickerStyle(.menu)
                 .onChange(of: tm.selectedProvider) { _, newValue in
                     tm.selectedAIModel = newValue.defaultModel
                     if newValue.requiresAPIKey && apiKeyInput.isEmpty {


### PR DESCRIPTION
## Summary
- Settings now opens as a 520px right-side panel alongside the main content
- Main content (recordings, transcripts, empty state) stays visible when settings is open
- Animated slide-in transition from the right edge
- Gear button toggles the panel open/closed

## Before
Clicking settings replaced the entire detail area — you lost sight of your content.

## After
```
[Meetings Sidebar | Main Content | Settings Panel]
```
Settings slides in from the right. Main content shrinks but stays visible.

## Test plan
- [ ] Click gear — settings panel slides in on the right
- [ ] Main content remains visible on the left
- [ ] Click gear again — panel slides out
- [ ] Select a meeting while settings is open — detail content updates
- [ ] All settings sections work in the narrower panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Settings interface redesigned to display in a dedicated right-side panel alongside the main content, with smooth entrance and exit animations
  * Settings toggle in the toolbar now includes animated transitions when activated for better visual feedback
  * AI provider picker style updated from segmented control to menu-based selector

<!-- end of auto-generated comment: release notes by coderabbit.ai -->