### PR TITLE
Fix: Recording entry not updating after transcription/summary

### DIFF
--- a/EchoNotes/Models/RecordingLibrary.swift
+++ b/EchoNotes/Models/RecordingLibrary.swift
@@ -21,7 +21,9 @@ struct RecordingEntry: Identifiable, Hashable, Sendable {
     }
 
     static func == (lhs: RecordingEntry, rhs: RecordingEntry) -> Bool {
-        lhs.id == rhs.id
+        lhs.id == rhs.id &&
+        lhs.hasTranscript == rhs.hasTranscript &&
+        lhs.transcriptPreview == rhs.transcriptPreview
     }
 
     /// Load a Transcript from the associated .json file, falling back to .txt if needed.

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -312,6 +312,11 @@ final class TranscriptionManager: ObservableObject {
             let mdURL = transcript.recordingURL.deletingPathExtension().appendingPathExtension("md")
             try result.toMarkdown().write(to: mdURL, atomically: true, encoding: .utf8)
 
+            // Save as .summary.json so RecordingDetailView can load it
+            let jsonURL = transcript.recordingURL.deletingPathExtension().appendingPathExtension("summary.json")
+            let encoded = try JSONEncoder().encode(result)
+            try encoded.write(to: jsonURL, options: .atomic)
+
             debugLog.info("Summary generated successfully", category: "AI")
             self.summary = result
         } catch {

--- a/EchoNotes/Views/MainWindowView.swift
+++ b/EchoNotes/Views/MainWindowView.swift
@@ -51,6 +51,16 @@ struct MainWindowView: View {
             if !isTranscribing {
                 // Re-scan after transcription completes so transcript preview updates
                 library.scan()
+                // Auto-select the newly transcribed recording
+                if let url = tm.transcript?.recordingURL {
+                    selectedEntryID = url
+                }
+            }
+        }
+        .onChange(of: tm.isSummarizing) { _, isSummarizing in
+            if !isSummarizing {
+                // Re-scan after summary so the entry reflects updated state
+                library.scan()
             }
         }
     }


### PR DESCRIPTION
## Summary
- **RecordingEntry equality** only compared `id` (URL), so SwiftUI never re-rendered sidebar rows when `hasTranscript`/`transcriptPreview` changed after rescan
- **TranscriptionManager.summarize()** saved `.md` but not `.summary.json`, so RecordingDetailView couldn't find the summary when loading from disk
- **Auto-select**: after transcription completes, the new entry is now automatically selected in the sidebar
- **Rescan after summary**: library rescans when summarization finishes so entry state stays fresh

## Test plan
- [ ] Record → transcribe → verify entry updates from "Not transcribed" to showing transcript preview
- [ ] Verify entry is auto-selected after transcription completes
- [ ] Generate summary → click away → click back → verify summary persists (loaded from .summary.json)