### PR TITLE
Fix: AI Provider dropdown as single source of truth

### DIFF
--- a/EchoNotes/Views/DesktopSettingsView.swift
+++ b/EchoNotes/Views/DesktopSettingsView.swift
@@ -141,21 +141,20 @@ struct DesktopSettingsView: View {
                     }
                     .buttonStyle(.bordered)
                     .disabled(tm.customEndpoint.isEmpty || isTesting)
+                }
 
-                    Button(action: {
-                        tm.selectedProvider = .custom
-                        tm.selectedAIModel = tm.customModel.isEmpty ? "default" : tm.customModel
-                    }) {
-                        Text(tm.selectedProvider == .custom ? "Active" : "Use This Provider")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(tm.customEndpoint.isEmpty || tm.selectedProvider == .custom)
-
-                    if tm.selectedProvider == .custom {
-                        Label("Currently active", systemImage: "checkmark.circle.fill")
-                            .font(.callout)
+                if tm.selectedProvider == .custom {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
                             .foregroundStyle(.green)
+                        Text("Selected as active provider in AI Providers")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
                     }
+                } else {
+                    Text("To use this provider, select \"Custom (OpenAI-compatible)\" in AI Providers.")
+                        .font(.callout)
+                        .foregroundStyle(.tertiary)
                 }
 
                 if let result = connectionTestResult {

--- a/EchoNotes/Views/SettingsView.swift
+++ b/EchoNotes/Views/SettingsView.swift
@@ -145,12 +145,28 @@ struct SettingsView: View {
                     .font(.callout.bold())
                     .foregroundStyle(.secondary)
 
-                Picker("", selection: $tm.selectedAIModel) {
-                    ForEach(tm.selectedProvider.modelOptions, id: \.self) { model in
-                        Text(model).tag(model)
+                if tm.selectedProvider == .custom {
+                    // Show custom model from Custom Providers config
+                    if tm.customModel.isEmpty {
+                        Text("Not configured — set up in Custom Providers")
+                            .font(.callout)
+                            .foregroundStyle(.tertiary)
+                    } else {
+                        Text(tm.customModel)
+                            .font(.callout)
+                            .padding(.vertical, 4)
+                            .padding(.horizontal, 8)
+                            .background(Color.secondary.opacity(0.1))
+                            .cornerRadius(4)
                     }
+                } else {
+                    Picker("", selection: $tm.selectedAIModel) {
+                        ForEach(tm.selectedProvider.modelOptions, id: \.self) { model in
+                            Text(model).tag(model)
+                        }
+                    }
+                    .pickerStyle(.menu)
                 }
-                .pickerStyle(.menu)
             }
 
             // API Key (if required and not using OAuth)
@@ -208,6 +224,24 @@ struct SettingsView: View {
                                 .font(.callout)
                                 .foregroundStyle(.green)
                         }
+                    }
+                }
+            } else if tm.selectedProvider == .custom {
+                if !tm.customEndpoint.isEmpty {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text("Using custom endpoint — configure in Custom Providers")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    HStack(spacing: 4) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundStyle(.orange)
+                        Text("Set up your endpoint in Custom Providers first")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
                     }
                 }
             } else if !tm.selectedProvider.requiresAPIKey {


### PR DESCRIPTION
## Summary
- Provider dropdown in AI Providers is now the only way to select the active provider
- When "Custom (OpenAI-compatible)" is selected, shows the configured model name and endpoint status instead of an empty picker
- Removed "Use This Provider" / "Active" buttons from Custom Providers — it's purely a configuration page now
- Added guidance text in both sections so users know how they connect

## Test plan
- [ ] Select Custom in AI Providers dropdown → shows model name from Custom Providers config
- [ ] Select Custom with no endpoint configured → shows warning to set up in Custom Providers
- [ ] Custom Providers page shows status of whether it's the active provider
- [ ] Other providers (OpenAI, Anthropic, etc.) still work normally with model picker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated custom AI provider interface to display status indicators and guidance messages instead of interactive buttons, making provider configuration status clearer.
  * Enhanced model picker behavior: when a custom provider is selected, displays the configured model or a setup prompt; non-custom providers show the standard model selection menu.
  * Added visual indicators (checkmarks and warnings) with helpful guidance for custom provider endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->