### PR TITLE
Merge Custom Providers into AI Providers section

### DIFF
--- a/EchoNotes/Views/DesktopSettingsView.swift
+++ b/EchoNotes/Views/DesktopSettingsView.swift
@@ -9,9 +9,6 @@ struct DesktopSettingsView: View {
 
     let section: AppSection
 
-    @State private var connectionTestResult: ConnectionTestResult?
-    @State private var isTesting = false
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
@@ -37,8 +34,6 @@ struct DesktopSettingsView: View {
             generalContent
         case .aiProviders:
             aiContent
-        case .customProviders:
-            customContent
         case .knowledgeBase:
             knowledgeBaseContent
         case .developer:
@@ -95,79 +90,6 @@ struct DesktopSettingsView: View {
         ScrollView {
             SettingsView(tm: tm)
                 .padding(20)
-        }
-    }
-
-    // MARK: - Custom Providers
-
-    private var customContent: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                Text("Connect to any OpenAI-compatible API endpoint (llama.cpp, vLLM, LM Studio, etc).")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-
-                settingsGroup("Endpoint") {
-                    TextField("URL", text: $tm.customEndpoint, prompt: Text("http://localhost:8080/v1/chat/completions"))
-                        .textFieldStyle(.roundedBorder)
-                }
-
-                settingsGroup("Model") {
-                    TextField("Model name", text: $tm.customModel, prompt: Text("e.g. qwen3.5-35b-a3b"))
-                        .textFieldStyle(.roundedBorder)
-                    Text("The model name sent in the request body.")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
-
-                settingsGroup("API Key") {
-                    SecureField("API key", text: $tm.customAPIKey, prompt: Text("Leave empty if not required"))
-                        .textFieldStyle(.roundedBorder)
-                    Text("Only needed if your server requires authentication.")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
-
-                HStack(spacing: 10) {
-                    Button(action: { testConnection() }) {
-                        HStack(spacing: 4) {
-                            if isTesting {
-                                ProgressView().controlSize(.small)
-                            } else {
-                                Image(systemName: "network")
-                            }
-                            Text(isTesting ? "Testing..." : "Test Connection")
-                        }
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(tm.customEndpoint.isEmpty || isTesting)
-                }
-
-                if tm.selectedProvider == .custom {
-                    HStack(spacing: 4) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                        Text("Selected as active provider in AI Providers")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                    }
-                } else {
-                    Text("To use this provider, select \"Custom (OpenAI-compatible)\" in AI Providers.")
-                        .font(.callout)
-                        .foregroundStyle(.tertiary)
-                }
-
-                if let result = connectionTestResult {
-                    HStack(spacing: 6) {
-                        Image(systemName: result.success ? "checkmark.circle.fill" : "xmark.circle.fill")
-                            .foregroundStyle(result.success ? .green : .red)
-                        Text(result.message)
-                            .font(.callout)
-                            .foregroundColor(result.success ? .primary : .red)
-                    }
-                }
-            }
-            .padding(20)
         }
     }
 
@@ -382,64 +304,4 @@ struct DesktopSettingsView: View {
         }
     }
 
-    // MARK: - Test Connection
-
-    private func testConnection() {
-        guard let url = URL(string: tm.customEndpoint) else {
-            connectionTestResult = ConnectionTestResult(success: false, message: "Invalid URL")
-            return
-        }
-
-        isTesting = true
-        connectionTestResult = nil
-
-        Task {
-            do {
-                let model = tm.customModel.isEmpty ? "default" : tm.customModel
-                let body: [String: Any] = [
-                    "model": model,
-                    "messages": [["role": "user", "content": "Say hi"]],
-                    "max_tokens": 5
-                ]
-
-                var request = URLRequest(url: url)
-                request.httpMethod = "POST"
-                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-                if !tm.customAPIKey.isEmpty {
-                    request.setValue("Bearer \(tm.customAPIKey)", forHTTPHeaderField: "Authorization")
-                }
-                request.httpBody = try JSONSerialization.data(withJSONObject: body)
-                request.timeoutInterval = 10
-
-                let (data, response) = try await URLSession.shared.data(for: request)
-
-                guard let http = response as? HTTPURLResponse else {
-                    connectionTestResult = ConnectionTestResult(success: false, message: "No response")
-                    isTesting = false
-                    return
-                }
-
-                if http.statusCode == 200 {
-                    var detail = "Connected (HTTP 200)"
-                    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                       let responseModel = json["model"] as? String {
-                        detail = "Connected — model: \(responseModel)"
-                    }
-                    connectionTestResult = ConnectionTestResult(success: true, message: detail)
-                } else {
-                    let body = String(data: data, encoding: .utf8) ?? ""
-                    let short = body.prefix(100)
-                    connectionTestResult = ConnectionTestResult(success: false, message: "HTTP \(http.statusCode): \(short)")
-                }
-            } catch {
-                connectionTestResult = ConnectionTestResult(success: false, message: error.localizedDescription)
-            }
-            isTesting = false
-        }
-    }
-}
-
-private struct ConnectionTestResult {
-    let success: Bool
-    let message: String
 }

--- a/EchoNotes/Views/MainWindowView.swift
+++ b/EchoNotes/Views/MainWindowView.swift
@@ -5,7 +5,7 @@ enum AppSection: String, CaseIterable, Identifiable {
     case meetings = "Meetings"
     case general = "General"
     case aiProviders = "AI Providers"
-    case customProviders = "Custom Providers"
+
     case knowledgeBase = "Knowledge Base"
     case developer = "Developer"
     case about = "About"
@@ -17,7 +17,7 @@ enum AppSection: String, CaseIterable, Identifiable {
         case .meetings: return "list.bullet"
         case .general: return "gearshape"
         case .aiProviders: return "sparkles"
-        case .customProviders: return "plus.circle"
+
         case .knowledgeBase: return "book.closed"
         case .developer: return "chevron.left.forwardslash.chevron.right"
         case .about: return "info.circle"
@@ -103,7 +103,7 @@ struct MainWindowView: View {
                         .padding(.bottom, 8)
 
                     sectionHeader("Configuration")
-                    ForEach([AppSection.general, .aiProviders, .customProviders, .knowledgeBase], id: \.self) { section in
+                    ForEach([AppSection.general, .aiProviders, .knowledgeBase], id: \.self) { section in
                         sidebarRow(section)
                     }
 

--- a/EchoNotes/Views/SettingsView.swift
+++ b/EchoNotes/Views/SettingsView.swift
@@ -8,6 +8,8 @@ struct SettingsView: View {
     @State private var apiKeyInput: String = ""
     @State private var showKey = false
     @State private var saved = false
+    @State private var connectionTestResult: ConnectionTestResult?
+    @State private var isTesting = false
 
     var body: some View {
         VStack(spacing: 12) {
@@ -139,27 +141,13 @@ struct SettingsView: View {
                 }
             }
 
-            // Model picker
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Model")
-                    .font(.callout.bold())
-                    .foregroundStyle(.secondary)
+            // Model picker (not shown for custom — it's in the endpoint config below)
+            if tm.selectedProvider != .custom {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Model")
+                        .font(.callout.bold())
+                        .foregroundStyle(.secondary)
 
-                if tm.selectedProvider == .custom {
-                    // Show custom model from Custom Providers config
-                    if tm.customModel.isEmpty {
-                        Text("Not configured — set up in Custom Providers")
-                            .font(.callout)
-                            .foregroundStyle(.tertiary)
-                    } else {
-                        Text(tm.customModel)
-                            .font(.callout)
-                            .padding(.vertical, 4)
-                            .padding(.horizontal, 8)
-                            .background(Color.secondary.opacity(0.1))
-                            .cornerRadius(4)
-                    }
-                } else {
                     Picker("", selection: $tm.selectedAIModel) {
                         ForEach(tm.selectedProvider.modelOptions, id: \.self) { model in
                             Text(model).tag(model)
@@ -227,23 +215,7 @@ struct SettingsView: View {
                     }
                 }
             } else if tm.selectedProvider == .custom {
-                if !tm.customEndpoint.isEmpty {
-                    HStack(spacing: 4) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                        Text("Using custom endpoint — configure in Custom Providers")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                    }
-                } else {
-                    HStack(spacing: 4) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .foregroundStyle(.orange)
-                        Text("Set up your endpoint in Custom Providers first")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                customEndpointSection
             } else if !tm.selectedProvider.requiresAPIKey {
                 HStack(spacing: 4) {
                     Image(systemName: "checkmark.circle.fill")
@@ -258,4 +230,130 @@ struct SettingsView: View {
         .background(Color.secondary.opacity(0.05))
         .cornerRadius(8)
     }
+
+    // MARK: - Custom Endpoint
+
+    private var customEndpointSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Connect to any OpenAI-compatible API (llama.cpp, vLLM, LM Studio, etc).")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Endpoint")
+                    .font(.callout.bold())
+                    .foregroundStyle(.secondary)
+                TextField("URL", text: $tm.customEndpoint, prompt: Text("http://localhost:8080/v1/chat/completions"))
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Model")
+                    .font(.callout.bold())
+                    .foregroundStyle(.secondary)
+                TextField("Model name", text: $tm.customModel, prompt: Text("e.g. qwen3.5-35b-a3b"))
+                    .textFieldStyle(.roundedBorder)
+                Text("The model name sent in the request body.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("API Key")
+                    .font(.callout.bold())
+                    .foregroundStyle(.secondary)
+                SecureField("API key", text: $tm.customAPIKey, prompt: Text("Leave empty if not required"))
+                    .textFieldStyle(.roundedBorder)
+                Text("Only needed if your server requires authentication.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            HStack(spacing: 10) {
+                Button(action: { testCustomConnection() }) {
+                    HStack(spacing: 4) {
+                        if isTesting {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Image(systemName: "network")
+                        }
+                        Text(isTesting ? "Testing..." : "Test Connection")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(tm.customEndpoint.isEmpty || isTesting)
+            }
+
+            if let result = connectionTestResult {
+                HStack(spacing: 6) {
+                    Image(systemName: result.success ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(result.success ? .green : .red)
+                    Text(result.message)
+                        .font(.callout)
+                        .foregroundColor(result.success ? .primary : .red)
+                }
+            }
+        }
+    }
+
+    // MARK: - Test Connection
+
+    private func testCustomConnection() {
+        guard let url = URL(string: tm.customEndpoint) else {
+            connectionTestResult = ConnectionTestResult(success: false, message: "Invalid URL")
+            return
+        }
+
+        isTesting = true
+        connectionTestResult = nil
+
+        Task {
+            do {
+                let model = tm.customModel.isEmpty ? "default" : tm.customModel
+                let body: [String: Any] = [
+                    "model": model,
+                    "messages": [["role": "user", "content": "Say hi"]],
+                    "max_tokens": 5
+                ]
+
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                if !tm.customAPIKey.isEmpty {
+                    request.setValue("Bearer \(tm.customAPIKey)", forHTTPHeaderField: "Authorization")
+                }
+                request.httpBody = try JSONSerialization.data(withJSONObject: body)
+                request.timeoutInterval = 10
+
+                let (data, response) = try await URLSession.shared.data(for: request)
+
+                guard let http = response as? HTTPURLResponse else {
+                    connectionTestResult = ConnectionTestResult(success: false, message: "No response")
+                    isTesting = false
+                    return
+                }
+
+                if http.statusCode == 200 {
+                    var detail = "Connected (HTTP 200)"
+                    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let responseModel = json["model"] as? String {
+                        detail = "Connected — model: \(responseModel)"
+                    }
+                    connectionTestResult = ConnectionTestResult(success: true, message: detail)
+                } else {
+                    let body = String(data: data, encoding: .utf8) ?? ""
+                    let short = body.prefix(100)
+                    connectionTestResult = ConnectionTestResult(success: false, message: "HTTP \(http.statusCode): \(short)")
+                }
+            } catch {
+                connectionTestResult = ConnectionTestResult(success: false, message: error.localizedDescription)
+            }
+            isTesting = false
+        }
+    }
+}
+
+private struct ConnectionTestResult {
+    let success: Bool
+    let message: String
 }


### PR DESCRIPTION
## Summary
- Removes the separate "Custom Providers" sidebar section — its config (endpoint, model, API key, test connection) now appears inline in **AI Providers** when "Custom (OpenAI-compatible)" is selected from the provider dropdown
- Removes `customProviders` case from `AppSection` enum and sidebar navigation
- Cleans up duplicate `ConnectionTestResult` and `testConnection()` from `DesktopSettingsView`

## Test plan
- [ ] Select "Custom (OpenAI-compatible)" in AI Providers → endpoint/model/key fields appear inline
- [ ] Select any other provider → custom fields hidden
- [ ] Verify "Custom Providers" no longer appears in sidebar
- [ ] Test Connection button works from inline config
- [ ] Build passes (`./scripts/build-app.sh`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom endpoint configuration section with connection testing capability for validated endpoint connections.

* **Refactor**
  * Simplified custom provider settings structure by removing the dedicated custom providers menu option and consolidating functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->