### PR TITLE
Add Anthropic subscription auth via setup-token

### DIFF
--- a/EchoNotes/AI/AIService.swift
+++ b/EchoNotes/AI/AIService.swift
@@ -38,13 +38,15 @@ final class AIService: Sendable {
         let endpoint: URL
         let provider: AIProvider
         let chatgptAccountId: String?
+        let anthropicBearerAuth: Bool
 
-        init(apiKey: String, model: String = "gpt-4o-mini", endpoint: URL = URL(string: "https://api.openai.com/v1/chat/completions")!, provider: AIProvider = .openai, chatgptAccountId: String? = nil) {
+        init(apiKey: String, model: String = "gpt-4o-mini", endpoint: URL = URL(string: "https://api.openai.com/v1/chat/completions")!, provider: AIProvider = .openai, chatgptAccountId: String? = nil, anthropicBearerAuth: Bool = false) {
             self.apiKey = apiKey
             self.model = model
             self.endpoint = endpoint
             self.provider = provider
             self.chatgptAccountId = chatgptAccountId
+            self.anthropicBearerAuth = anthropicBearerAuth
         }
     }
 
@@ -269,7 +271,11 @@ final class AIService: Sendable {
 
         var request = URLRequest(url: config.endpoint)
         request.httpMethod = "POST"
-        request.setValue(config.apiKey, forHTTPHeaderField: "x-api-key")
+        if config.anthropicBearerAuth {
+            request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        } else {
+            request.setValue(config.apiKey, forHTTPHeaderField: "x-api-key")
+        }
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -41,6 +41,7 @@ final class TranscriptionManager: ObservableObject {
     private static let customAPIKeyDefaultsKey = "customAPIKey"
     private static let knowledgeBasePathDefaultsKey = "knowledgeBasePath"
     private static let useKnowledgeBaseDefaultsKey = "useKnowledgeBase"
+    private static let anthropicSetupTokenDefaultsKey = "anthropicSetupToken"
 
     /// API key for the selected AI provider.
     @Published var openaiAPIKey: String = UserDefaults.standard.string(forKey: apiKeyDefaultsKey) ?? "" {
@@ -98,6 +99,15 @@ final class TranscriptionManager: ObservableObject {
         didSet { UserDefaults.standard.set(useKnowledgeBase, forKey: Self.useKnowledgeBaseDefaultsKey) }
     }
 
+    /// Setup token from `claude setup-token` for Anthropic subscription auth.
+    @Published var anthropicSetupToken: String = UserDefaults.standard.string(forKey: anthropicSetupTokenDefaultsKey) ?? "" {
+        didSet { UserDefaults.standard.set(anthropicSetupToken, forKey: Self.anthropicSetupTokenDefaultsKey) }
+    }
+
+    var isAnthropicSubscriptionAuthenticated: Bool {
+        !anthropicSetupToken.isEmpty
+    }
+
     /// OAuth manager for ChatGPT login
     let oauthManager = OAuthManager()
     private var oauthCancellable: AnyCancellable?
@@ -111,17 +121,18 @@ final class TranscriptionManager: ObservableObject {
 
     /// Whether the current provider is configured and ready to use.
     var isAIConfigured: Bool {
-        // OAuth: either API key or access token via ChatGPT backend
-        if selectedProvider == .openai, oauthManager.isAuthenticated {
+        switch selectedProvider {
+        case .openai:
+            return oauthManager.isAuthenticated || !openaiAPIKey.isEmpty
+        case .anthropic:
+            return !anthropicAPIKey.isEmpty || !anthropicSetupToken.isEmpty
+        case .google:
+            return !googleAPIKey.isEmpty
+        case .custom:
+            return !customEndpoint.isEmpty
+        case .ollama:
             return true
         }
-        if selectedProvider == .custom {
-            return !customEndpoint.isEmpty
-        }
-        if selectedProvider.requiresAPIKey {
-            return !openaiAPIKey.isEmpty
-        }
-        return true // Ollama doesn't need a key
     }
 
     /// Build an AIService.Configuration from current settings.
@@ -149,6 +160,17 @@ final class TranscriptionManager: ObservableObject {
             }
         }
 
+        // Anthropic subscription auth via setup token
+        if selectedProvider == .anthropic, !anthropicSetupToken.isEmpty {
+            return AIService.Configuration(
+                apiKey: anthropicSetupToken,
+                model: selectedAIModel,
+                endpoint: URL(string: selectedProvider.defaultEndpoint)!,
+                provider: selectedProvider,
+                anthropicBearerAuth: true
+            )
+        }
+
         if selectedProvider == .custom {
             return AIService.Configuration(
                 apiKey: customAPIKey,
@@ -158,8 +180,17 @@ final class TranscriptionManager: ObservableObject {
             )
         }
 
+        // Per-provider API key
+        let apiKey: String
+        switch selectedProvider {
+        case .openai: apiKey = openaiAPIKey
+        case .anthropic: apiKey = anthropicAPIKey
+        case .google: apiKey = googleAPIKey
+        default: apiKey = ""
+        }
+
         return AIService.Configuration(
-            apiKey: openaiAPIKey,
+            apiKey: apiKey,
             model: selectedAIModel,
             endpoint: URL(string: selectedProvider.defaultEndpoint)!,
             provider: selectedProvider

--- a/EchoNotes/Views/SettingsView.swift
+++ b/EchoNotes/Views/SettingsView.swift
@@ -29,13 +29,20 @@ struct SettingsView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    oauthSection
+                    if tm.selectedProvider == .openai {
+                        oauthSection
+                    } else if tm.selectedProvider == .anthropic {
+                        anthropicSubscriptionSection
+                    }
                     aiProviderSection
                 }
             }
         }
         .onAppear {
-            apiKeyInput = tm.openaiAPIKey
+            apiKeyInput = currentAPIKey
+        }
+        .onChange(of: tm.selectedProvider) { _, _ in
+            apiKeyInput = currentAPIKey
         }
     }
 
@@ -99,6 +106,105 @@ struct SettingsView: View {
         .cornerRadius(8)
     }
 
+    // MARK: - Per-Provider API Key Helpers
+
+    private var currentAPIKey: String {
+        switch tm.selectedProvider {
+        case .openai: return tm.openaiAPIKey
+        case .anthropic: return tm.anthropicAPIKey
+        case .google: return tm.googleAPIKey
+        default: return ""
+        }
+    }
+
+    private func saveAPIKey(_ key: String) {
+        switch tm.selectedProvider {
+        case .openai: tm.openaiAPIKey = key
+        case .anthropic: tm.anthropicAPIKey = key
+        case .google: tm.googleAPIKey = key
+        default: break
+        }
+    }
+
+    // MARK: - Anthropic Subscription Section
+
+    @State private var anthropicTokenInput: String = ""
+
+    private var anthropicSubscriptionSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("Claude Subscription Auth", systemImage: "person.crop.circle")
+                .font(.subheadline.bold())
+
+            Text("Use your Claude Max/Pro subscription instead of an API key. Requires the Claude Code CLI.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            if tm.isAnthropicSubscriptionAuthenticated {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text("Using your Claude subscription for Anthropic API access")
+                        .font(.callout.bold())
+                    Spacer()
+                    Button(action: { tm.anthropicSetupToken = "" }) {
+                        Text("Sign Out")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("1. Run this command in Terminal:")
+                        .font(.callout)
+                    HStack(spacing: 6) {
+                        Text("`claude setup-token`")
+                            .font(.system(.callout, design: .monospaced))
+                            .foregroundStyle(.primary)
+                        Button(action: {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString("claude setup-token", forType: .string)
+                        }) {
+                            Image(systemName: "doc.on.doc")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                        .help("Copy command")
+                    }
+                    Text("2. Paste the token below:")
+                        .font(.callout)
+                    SecureField("Paste setup token...", text: $anthropicTokenInput)
+                        .textFieldStyle(.roundedBorder)
+                    Button(action: {
+                        let trimmed = anthropicTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            tm.anthropicSetupToken = trimmed
+                            anthropicTokenInput = ""
+                        }
+                    }) {
+                        Text("Save Token")
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 4)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(anthropicTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+
+            HStack(spacing: 4) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.yellow)
+                    .font(.caption)
+                Text("Anthropic may restrict subscription usage outside Claude Code. Use at your own risk.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .background(Color.secondary.opacity(0.05))
+        .cornerRadius(8)
+    }
+
     // MARK: - AI Provider Section
 
     private var aiProviderSection: some View {
@@ -112,6 +218,15 @@ struct SettingsView: View {
                         .font(.callout)
                         .foregroundStyle(.green)
                     Text("Using your ChatGPT account for OpenAI API access")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            } else if tm.isAnthropicSubscriptionAuthenticated && tm.selectedProvider == .anthropic {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.callout)
+                        .foregroundStyle(.green)
+                    Text("Using your Claude subscription for Anthropic API access")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
@@ -157,8 +272,10 @@ struct SettingsView: View {
                 }
             }
 
-            // API Key (if required and not using OAuth)
-            if tm.selectedProvider.requiresAPIKey && !(tm.oauthManager.isAuthenticated && tm.selectedProvider == .openai) {
+            // API Key (if required and not using OAuth or subscription auth)
+            if tm.selectedProvider.requiresAPIKey
+                && !(tm.oauthManager.isAuthenticated && tm.selectedProvider == .openai)
+                && !(tm.isAnthropicSubscriptionAuthenticated && tm.selectedProvider == .anthropic) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("API Key")
                         .font(.callout.bold())
@@ -183,7 +300,7 @@ struct SettingsView: View {
 
                     HStack(spacing: 8) {
                         Button(action: {
-                            tm.openaiAPIKey = apiKeyInput
+                            saveAPIKey(apiKeyInput)
                             saved = true
                             DispatchQueue.main.asyncAfter(deadline: .now() + 2) { saved = false }
                         }) {
@@ -191,11 +308,11 @@ struct SettingsView: View {
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
-                        .disabled(apiKeyInput == tm.openaiAPIKey)
+                        .disabled(apiKeyInput == currentAPIKey)
 
-                        if !tm.openaiAPIKey.isEmpty {
+                        if !currentAPIKey.isEmpty {
                             Button(action: {
-                                tm.openaiAPIKey = ""
+                                saveAPIKey("")
                                 apiKeyInput = ""
                             }) {
                                 Text("Remove Key")


### PR DESCRIPTION
## Summary

- Adds Claude Max/Pro subscription authentication using `claude setup-token` (OAuth Bearer token against `api.anthropic.com/v1/messages`)
- Settings UI: paste token flow with instructions, copy command button, sign out, and risk disclaimer warning that Anthropic may restrict subscription usage outside Claude Code
- **Bug fix**: `isAIConfigured` and `aiConfiguration()` were using `openaiAPIKey` for all providers — now correctly checks/uses per-provider API keys (Anthropic, Google, etc.)
- **Bug fix**: SettingsView Save/Remove API key buttons always wrote to `openaiAPIKey` regardless of selected provider

## Known limitations

- Setup token expires (~1 year) with no auto-refresh — user must re-paste
- Anthropic's ToS restricts OAuth tokens to Claude Code/Claude.ai; feature may stop working if Anthropic enforces this server-side

## Test plan

- [ ] Select Anthropic provider — subscription section appears, OAuth section hidden
- [ ] Paste a token — shows authenticated state with green checkmark
- [ ] "Sign Out" clears token, returns to paste flow
- [ ] API key field hidden when subscription auth is active
- [ ] Select OpenAI — subscription section hidden, OAuth section shown
- [ ] Verify per-provider API key save/remove works correctly for Anthropic, Google, OpenAI
- [ ] `./scripts/build-app.sh` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Anthropic API authentication via subscription token.
  * New Anthropic subscription section in settings with token management and sign-out functionality.
  * Enhanced provider-specific API key configuration for better multi-provider support.
  * Added subscription status indicator for Anthropic authentication state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->