### PR TITLE
Fix: Replace deprecated cornerRadius() and foregroundColor()

### DIFF
--- a/EchoNotes/Views/AIProvidersSettingsView.swift
+++ b/EchoNotes/Views/AIProvidersSettingsView.swift
@@ -62,7 +62,7 @@ struct AIProvidersSettingsView: View {
         }
         .padding(16)
                 .background(isSelected(provider) ? Color.orange.opacity(0.1) : Color.gray.opacity(0.1))
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private func isSelected(_ provider: AIProvider) -> Bool {

--- a/EchoNotes/Views/ActiveRecordingView.swift
+++ b/EchoNotes/Views/ActiveRecordingView.swift
@@ -26,7 +26,7 @@ struct ActiveRecordingView: View {
                     .multilineTextAlignment(.center)
                     .padding()
                     .background(Color.red.opacity(0.1))
-                    .cornerRadius(8)
+                    .clipShape(.rect(cornerRadius: 8))
             }
         }
         .padding(20)

--- a/EchoNotes/Views/LibraryView.swift
+++ b/EchoNotes/Views/LibraryView.swift
@@ -47,7 +47,7 @@ struct LibraryView: View {
             }
             .padding(6)
             .background(Color.secondary.opacity(0.1))
-            .cornerRadius(6)
+            .clipShape(.rect(cornerRadius: 6))
 
             if library.filteredEntries.isEmpty {
                 Spacer()
@@ -114,7 +114,7 @@ private struct RecordingRow: View {
             }
             .padding(8)
             .background(Color.secondary.opacity(0.05))
-            .cornerRadius(6)
+            .clipShape(.rect(cornerRadius: 6))
         }
         .buttonStyle(.plain)
         .contextMenu {

--- a/EchoNotes/Views/MainWindowView.swift
+++ b/EchoNotes/Views/MainWindowView.swift
@@ -149,7 +149,7 @@ struct MainWindowView: View {
                     ? Color.secondary.opacity(0.15)
                     : Color.clear
             )
-            .cornerRadius(6)
+            .clipShape(.rect(cornerRadius: 6))
         }
         .buttonStyle(.plain)
     }

--- a/EchoNotes/Views/RecordingDetailView.swift
+++ b/EchoNotes/Views/RecordingDetailView.swift
@@ -236,7 +236,7 @@ struct RecordingDetailView: View {
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.secondary.opacity(0.06))
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 
     private func bulletItem(_ text: String) -> some View {
@@ -307,7 +307,7 @@ struct RecordingDetailView: View {
         }
         .padding(12)
         .background(Color.secondary.opacity(0.06))
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 
     // MARK: - Summary Generation

--- a/EchoNotes/Views/SettingsView.swift
+++ b/EchoNotes/Views/SettingsView.swift
@@ -96,7 +96,7 @@ struct SettingsView: View {
         }
         .padding(12)
         .background(Color.secondary.opacity(0.05))
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 
     // MARK: - AI Provider Section
@@ -228,7 +228,7 @@ struct SettingsView: View {
         }
         .padding(12)
         .background(Color.secondary.opacity(0.05))
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 
     // MARK: - Custom Endpoint
@@ -290,7 +290,7 @@ struct SettingsView: View {
                         .foregroundStyle(result.success ? .green : .red)
                     Text(result.message)
                         .font(.callout)
-                        .foregroundColor(result.success ? .primary : .red)
+                        .foregroundStyle(result.success ? .primary : .red)
                 }
             }
         }


### PR DESCRIPTION
Addresses Issues #170 and #162

**Changes:**
- Replace .cornerRadius() with .clipShape(.rect(cornerRadius:)) in 10 locations
- Replace .foregroundColor() with .foregroundStyle() in 1 location

**Impact:** Eliminates deprecated API usage, future-proofs codebase for Swift 6.2+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI styling approach for rounded corners and text rendering across multiple views to maintain visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->