### PR TITLE
Fix: Live transcription not displaying segments during recording

### DIFF
--- a/EchoNotes/Models/Transcript.swift
+++ b/EchoNotes/Models/Transcript.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A single segment of transcribed speech with timing information.
-struct TranscriptSegment: Codable, Sendable, Equatable {
+struct TranscriptSegment: Codable, Sendable, Equatable, Hashable {
     let startTime: TimeInterval
     let endTime: TimeInterval
     let text: String

--- a/EchoNotes/Transcription/StreamingTranscriber.swift
+++ b/EchoNotes/Transcription/StreamingTranscriber.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 @preconcurrency import AVFoundation
 
 /// Transcribes audio in near-real-time during recording by processing chunks through Whisper.
@@ -12,6 +13,7 @@ import Foundation
 /// then drained on the MainActor for processing.
 @MainActor
 final class StreamingTranscriber: ObservableObject {
+    private let logger = Logger(subsystem: "com.echonotes", category: "StreamingTranscriber")
     @Published var segments: [TranscriptSegment] = []
     /// Older segments flushed from live memory to prevent unbounded growth.
     private(set) var flushedSegments: [TranscriptSegment] = []
@@ -59,9 +61,12 @@ final class StreamingTranscriber: ObservableObject {
 
         let threshold = Int(chunkSeconds * sampleRate)
         if count >= threshold {
+            logger.info("Threshold reached: \(count) samples (threshold: \(threshold)), triggering processing")
             Task { @MainActor in
                 self.drainAndProcess()
             }
+        } else {
+            logger.debug("Buffered \(count) samples (threshold: \(threshold))")
         }
     }
 
@@ -101,6 +106,7 @@ final class StreamingTranscriber: ObservableObject {
         let drained = incomingSamples
         incomingSamples.removeAll(keepingCapacity: true)
         sampleLock.unlock()
+        logger.info("drainAndProcess: \(drained.count) samples")
 
         guard !drained.isEmpty else { return }
         processChunk(drained)

--- a/EchoNotes/Views/ActiveRecordingView.swift
+++ b/EchoNotes/Views/ActiveRecordingView.swift
@@ -75,7 +75,7 @@ struct ActiveRecordingView: View {
                 ScrollViewReader { proxy in
                     ScrollView {
                         VStack(alignment: .leading, spacing: 4) {
-                            ForEach(Array(recentSegments.enumerated()), id: \.offset) { idx, segment in
+                            ForEach(tm.streamingTranscriber.segments, id: \.self) { segment in
                                 HStack(alignment: .top, spacing: 6) {
                                     if let speaker = segment.speaker {
                                         Text(speaker)
@@ -86,13 +86,12 @@ struct ActiveRecordingView: View {
                                         .font(.body)
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                 }
-                                .id(idx)
                             }
                         }
                     }
                     .onChange(of: tm.streamingTranscriber.segments.count) { _, newCount in
                         if newCount > 0 {
-                            proxy.scrollTo(min(recentSegments.count - 1, 49), anchor: .bottom)
+                            proxy.scrollTo(newCount - 1, anchor: .bottom)
                         }
                     }
                 }


### PR DESCRIPTION
## Problem
Live transcription shows 'Listening...' but never displays segments during recording.

## Root Cause
SwiftUI view couldn't detect when new segments were appended to the @Published array. The ForEach used array index as ID, which isn't stable.

## Fix
Changed ForEach to use segment itself as ID and added Hashable conformance to TranscriptSegment.

## Files Changed
- EchoNotes/Views/ActiveRecordingView.swift
- EchoNotes/Models/Transcript.swift
- EchoNotes/Transcription/StreamingTranscriber.swift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed segment display and scrolling synchronization in the active recording view.

* **Refactor**
  * Improved internal data structure capabilities for segment management.
  * Enhanced diagnostic logging for transcription processing to better monitor system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->