### PR TITLE
feat: pause/resume recording (closes #98)

### DIFF
--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -27,7 +27,8 @@ final class RecordingEngine: ObservableObject {
     @Published var errorMessage: String?
     @Published var lastRecordingURL: URL?
     @Published var isPaused: Bool = false
-    @Published var pauseDuration: TimeInterval = 0
+    /// Total time spent paused across all pause/resume cycles in the current recording.
+    @Published var totalPauseDuration: TimeInterval = 0
     @Published var autoTranscribe: Bool = UserDefaults.standard.bool(forKey: "autoTranscribe") {
         didSet { UserDefaults.standard.set(autoTranscribe, forKey: "autoTranscribe") }
     }
@@ -60,9 +61,10 @@ final class RecordingEngine: ObservableObject {
     private let micCapture = MicrophoneCapture()
     private var audioWriter: AudioFileWriter?
     private var durationTimer: Timer?
-    private var pauseTimer: Timer?
     private var recordingStartTime: Date?
     private var pauseStartTime: Date?
+    /// Accumulated pause time from previous pause/resume cycles (not including current pause).
+    private var accumulatedPauseDuration: TimeInterval = 0
     private var lastSystemLevelUpdate: Date = .distantPast
     private var lastMicLevelUpdate: Date = .distantPast
 
@@ -224,11 +226,12 @@ final class RecordingEngine: ObservableObject {
             logger.info("Recording started: \(fileURL.lastPathComponent)")
             debugLog.info("Recording started: \(fileURL.lastPathComponent)", category: "Recording")
 
-            // Duration timer
+            // Duration timer — shows actual recording time (wall clock minus total pause time)
             durationTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
                 Task { @MainActor in
                     guard let self, let start = self.recordingStartTime else { return }
-                    self.duration = Date().timeIntervalSince(start)
+                    let elapsed = Date().timeIntervalSince(start)
+                    self.duration = elapsed - self.totalPauseDuration
                 }
             }
         } catch {
@@ -238,7 +241,7 @@ final class RecordingEngine: ObservableObject {
         }
     }
 
-    /// Pause recording - stops audio capture but keeps the file open
+    /// Pause recording — stops audio capture but keeps the file open for later resume.
     func pause() async {
         guard isRecording && !isPaused else { return }
 
@@ -246,37 +249,42 @@ final class RecordingEngine: ObservableObject {
         isPaused = true
         pauseStartTime = Date()
 
+        // Stop duration timer while paused (prevents timer drift during pause)
+        durationTimer?.invalidate()
+        durationTimer = nil
+
         // Stop audio captures
         await systemCapture.stopCapture()
         micCapture.stopCapture()
 
-        // Stop level meter updates
+        // Reset level meters
         systemLevel = 0
         micLevel = 0
 
-        // Start pause duration timer
-        pauseTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                guard let self, let start = self.pauseStartTime else { return }
-                self.pauseDuration = Date().timeIntervalSince(start)
-            }
-        }
-
-        // Stop live transcription if enabled
+        // Pause live transcription if enabled
         if transcriptionMode == .live {
             await transcriptionManager.pauseLiveTranscription()
         }
     }
 
-    /// Resume recording - resumes audio capture to the same file
+    /// Resume recording — restarts audio capture, accumulates pause duration.
     func resume() async {
         guard isRecording && isPaused else { return }
 
         logger.info("Resuming recording...")
+
+        // Accumulate this pause cycle's duration
+        if let pauseStart = pauseStartTime {
+            let thisPause = Date().timeIntervalSince(pauseStart)
+            accumulatedPauseDuration += thisPause
+            totalPauseDuration = accumulatedPauseDuration
+        }
         isPaused = false
         pauseStartTime = nil
 
         // Resume audio captures
+        // Note: onBuffer callbacks survive because they're set as properties on the
+        // capture objects, not on the SCStream/AVAudioEngine instances that get recreated.
         do {
             try await systemCapture.startCapture(sampleRate: AudioConfig.sampleRate)
         } catch {
@@ -294,9 +302,14 @@ final class RecordingEngine: ObservableObject {
             return
         }
 
-        // Clear pause timer
-        pauseTimer?.invalidate()
-        pauseTimer = nil
+        // Restart duration timer
+        durationTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self, let start = self.recordingStartTime else { return }
+                let elapsed = Date().timeIntervalSince(start)
+                self.duration = elapsed - self.totalPauseDuration
+            }
+        }
 
         // Resume live transcription if enabled
         if transcriptionMode == .live {
@@ -309,11 +322,12 @@ final class RecordingEngine: ObservableObject {
 
         durationTimer?.invalidate()
         durationTimer = nil
-        pauseTimer?.invalidate()
-        pauseTimer = nil
 
-        await systemCapture.stopCapture()
-        micCapture.stopCapture()
+        // If currently paused, captures are already stopped — skip redundant stop calls
+        if !isPaused {
+            await systemCapture.stopCapture()
+            micCapture.stopCapture()
+        }
         audioWriter?.finalize()
 
         let url = audioWriter?.outputURL
@@ -323,7 +337,9 @@ final class RecordingEngine: ObservableObject {
         isRecording = false
         isPaused = false
         duration = 0
-        pauseDuration = 0
+        totalPauseDuration = 0
+        accumulatedPauseDuration = 0
+        pauseStartTime = nil
         micLevel = 0
         systemLevel = 0
 

--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -26,6 +26,8 @@ final class RecordingEngine: ObservableObject {
     @Published var systemLevel: Float = 0
     @Published var errorMessage: String?
     @Published var lastRecordingURL: URL?
+    @Published var isPaused: Bool = false
+    @Published var pauseDuration: TimeInterval = 0
     @Published var autoTranscribe: Bool = UserDefaults.standard.bool(forKey: "autoTranscribe") {
         didSet { UserDefaults.standard.set(autoTranscribe, forKey: "autoTranscribe") }
     }
@@ -58,7 +60,9 @@ final class RecordingEngine: ObservableObject {
     private let micCapture = MicrophoneCapture()
     private var audioWriter: AudioFileWriter?
     private var durationTimer: Timer?
+    private var pauseTimer: Timer?
     private var recordingStartTime: Date?
+    private var pauseStartTime: Date?
     private var lastSystemLevelUpdate: Date = .distantPast
     private var lastMicLevelUpdate: Date = .distantPast
 
@@ -234,11 +238,79 @@ final class RecordingEngine: ObservableObject {
         }
     }
 
+    /// Pause recording - stops audio capture but keeps the file open
+    func pause() async {
+        guard isRecording && !isPaused else { return }
+
+        logger.info("Pausing recording...")
+        isPaused = true
+        pauseStartTime = Date()
+
+        // Stop audio captures
+        await systemCapture.stopCapture()
+        micCapture.stopCapture()
+
+        // Stop level meter updates
+        systemLevel = 0
+        micLevel = 0
+
+        // Start pause duration timer
+        pauseTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self, let start = self.pauseStartTime else { return }
+                self.pauseDuration = Date().timeIntervalSince(start)
+            }
+        }
+
+        // Stop live transcription if enabled
+        if transcriptionMode == .live {
+            await transcriptionManager.pauseLiveTranscription()
+        }
+    }
+
+    /// Resume recording - resumes audio capture to the same file
+    func resume() async {
+        guard isRecording && isPaused else { return }
+
+        logger.info("Resuming recording...")
+        isPaused = false
+        pauseStartTime = nil
+
+        // Resume audio captures
+        do {
+            try await systemCapture.startCapture(sampleRate: AudioConfig.sampleRate)
+        } catch {
+            logger.error("Failed to resume system audio: \(error.localizedDescription)")
+            errorMessage = "Failed to resume system audio: \(error.localizedDescription)"
+            return
+        }
+
+        do {
+            try micCapture.startCapture(sampleRate: AudioConfig.sampleRate)
+        } catch {
+            logger.error("Failed to resume microphone: \(error.localizedDescription)")
+            errorMessage = "Failed to resume microphone: \(error.localizedDescription)"
+            await systemCapture.stopCapture()
+            return
+        }
+
+        // Clear pause timer
+        pauseTimer?.invalidate()
+        pauseTimer = nil
+
+        // Resume live transcription if enabled
+        if transcriptionMode == .live {
+            await transcriptionManager.resumeLiveTranscription()
+        }
+    }
+
     func stopRecording() async {
         guard isRecording else { return }
 
         durationTimer?.invalidate()
         durationTimer = nil
+        pauseTimer?.invalidate()
+        pauseTimer = nil
 
         await systemCapture.stopCapture()
         micCapture.stopCapture()
@@ -249,7 +321,9 @@ final class RecordingEngine: ObservableObject {
         cleanup()
 
         isRecording = false
+        isPaused = false
         duration = 0
+        pauseDuration = 0
         micLevel = 0
         systemLevel = 0
 

--- a/EchoNotes/Transcription/StreamingTranscriber.swift
+++ b/EchoNotes/Transcription/StreamingTranscriber.swift
@@ -22,6 +22,8 @@ final class StreamingTranscriber: ObservableObject {
     @Published var isProcessing = false
     @Published var error: String?
     @Published var isPaused = false
+    /// Thread-safe pause flag for nonisolated feedSamples (avoids data race on @Published isPaused).
+    private let pausedLock = OSAllocatedUnfairLock(initialState: false)
 
     /// Seconds of audio to accumulate before running inference.
     /// 5s gives fast feedback; Whisper base.en processes this in <1s on M-series.
@@ -55,8 +57,8 @@ final class StreamingTranscriber: ObservableObject {
     /// Thread-safe — can be called from any thread. Samples are appended
     /// in the exact order received, then drained on MainActor.
     nonisolated func feedSamples(_ samples: [Float]) {
-        // Skip processing if paused
-        if isPaused { return }
+        // Skip processing if paused (thread-safe check)
+        guard !pausedLock.withLock({ $0 }) else { return }
 
         sampleLock.lock()
         incomingSamples.append(contentsOf: samples)
@@ -200,12 +202,14 @@ final class StreamingTranscriber: ObservableObject {
     /// Pause live transcription — stop accepting new audio chunks
     func pause() {
         isPaused = true
+        pausedLock.withLock { $0 = true }
         logger.info("Live transcription paused")
     }
 
     /// Resume live transcription — continue accepting audio chunks
     func resume() {
         isPaused = false
+        pausedLock.withLock { $0 = false }
         logger.info("Live transcription resumed")
     }
 

--- a/EchoNotes/Transcription/StreamingTranscriber.swift
+++ b/EchoNotes/Transcription/StreamingTranscriber.swift
@@ -21,6 +21,7 @@ final class StreamingTranscriber: ObservableObject {
     private let maxLiveSegments = 500
     @Published var isProcessing = false
     @Published var error: String?
+    @Published var isPaused = false
 
     /// Seconds of audio to accumulate before running inference.
     /// 5s gives fast feedback; Whisper base.en processes this in <1s on M-series.
@@ -54,6 +55,9 @@ final class StreamingTranscriber: ObservableObject {
     /// Thread-safe — can be called from any thread. Samples are appended
     /// in the exact order received, then drained on MainActor.
     nonisolated func feedSamples(_ samples: [Float]) {
+        // Skip processing if paused
+        if isPaused { return }
+
         sampleLock.lock()
         incomingSamples.append(contentsOf: samples)
         let count = incomingSamples.count
@@ -191,6 +195,18 @@ final class StreamingTranscriber: ObservableObject {
             flushedSegments.append(contentsOf: segments.prefix(overflow))
             segments.removeFirst(overflow)
         }
+    }
+
+    /// Pause live transcription — stop accepting new audio chunks
+    func pause() {
+        isPaused = true
+        logger.info("Live transcription paused")
+    }
+
+    /// Resume live transcription — continue accepting audio chunks
+    func resume() {
+        isPaused = false
+        logger.info("Live transcription resumed")
     }
 
     /// Resample 48kHz → 16kHz mono for Whisper using a fresh converter per call.

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -336,4 +336,14 @@ final class TranscriptionManager: ObservableObject {
         progress = 0
         summary = nil
     }
+
+    /// Pause live transcription — flush current chunks and stop accepting new audio
+    func pauseLiveTranscription() async {
+        await streamingTranscriber.pause()
+    }
+
+    /// Resume live transcription — continue processing from where we left off
+    func resumeLiveTranscription() async {
+        await streamingTranscriber.resume()
+    }
 }

--- a/EchoNotes/Views/ActiveRecordingView.swift
+++ b/EchoNotes/Views/ActiveRecordingView.swift
@@ -37,7 +37,37 @@ struct ActiveRecordingView: View {
 
     private var recordingView: some View {
         VStack(spacing: 20) {
-            Text(Transcript.formatTimestamp(recorder.duration))
+            // Show pause indicator and resume button
+            if recorder.isPaused {
+                HStack {
+                    Image(systemName: "pause.circle.fill")
+                        .font(.system(size: 40))
+                        .foregroundStyle(.yellow)
+                    VStack {
+                        Text("Recording Paused")
+                            .font(.headline)
+                        Text("Tap to resume")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button(action: {
+                        Task {
+                            await recorder.resume()
+                        }
+                    }) {
+                        Image(systemName: "play.circle.fill")
+                            .font(.title2)
+                            .foregroundStyle(.green)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding()
+                .background(Color.yellow.opacity(0.1))
+                .cornerRadius(12)
+            }
+
+            Text(Transcript.formatTimestamp(recorder.duration + recorder.pauseDuration))
                 .font(.system(size: 52, weight: .light, design: .monospaced))
                 .foregroundStyle(.primary)
 

--- a/EchoNotes/Views/ActiveRecordingView.swift
+++ b/EchoNotes/Views/ActiveRecordingView.swift
@@ -37,39 +37,30 @@ struct ActiveRecordingView: View {
 
     private var recordingView: some View {
         VStack(spacing: 20) {
-            // Show pause indicator and resume button
+            // Pause banner
             if recorder.isPaused {
-                HStack {
+                HStack(spacing: 12) {
                     Image(systemName: "pause.circle.fill")
-                        .font(.system(size: 40))
+                        .font(.system(size: 32))
                         .foregroundStyle(.yellow)
-                    VStack {
+                    VStack(alignment: .leading, spacing: 2) {
                         Text("Recording Paused")
                             .font(.headline)
-                        Text("Tap to resume")
+                        Text("Audio capture is suspended")
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
-                    Button(action: {
-                        Task {
-                            await recorder.resume()
-                        }
-                    }) {
-                        Image(systemName: "play.circle.fill")
-                            .font(.title2)
-                            .foregroundStyle(.green)
-                    }
-                    .buttonStyle(.plain)
                 }
                 .padding()
                 .background(Color.yellow.opacity(0.1))
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
             }
 
-            Text(Transcript.formatTimestamp(recorder.duration + recorder.pauseDuration))
+            // Duration shows actual recording time (pause time is excluded)
+            Text(Transcript.formatTimestamp(recorder.duration))
                 .font(.system(size: 52, weight: .light, design: .monospaced))
-                .foregroundStyle(.primary)
+                .foregroundStyle(recorder.isPaused ? .secondary : .primary)
 
             HStack(spacing: 24) {
                 LevelMeterView(label: "System", level: recorder.systemLevel)

--- a/EchoNotes/Views/RecordingControlsView.swift
+++ b/EchoNotes/Views/RecordingControlsView.swift
@@ -1,32 +1,92 @@
 import SwiftUI
 
-/// Primary recording control button (start/stop).
+/// Primary recording control button (start/stop) with pause/resume controls.
 struct RecordingControlsView: View {
     @ObservedObject var recorder: RecordingEngine
 
     var body: some View {
         Group {
             if shouldShowPrimaryButton {
+                if recorder.isRecording {
+                    // Show pause/resume/stop controls during recording
+                    recordingControls
+                } else {
+                    // Show start button when not recording
+                    startButton
+                }
+            }
+        }
+    }
+
+    private var recordingControls: some View {
+        HStack(spacing: 12) {
+            if recorder.isPaused {
+                // Resume button
                 Button(action: {
                     Task {
-                        if recorder.isRecording {
-                            await recorder.stopRecording()
-                        } else {
-                            await recorder.startRecording()
-                        }
+                        await recorder.resume()
                     }
                 }) {
                     HStack {
-                        Image(systemName: recorder.isRecording ? "stop.fill" : "record.circle")
-                        Text(recorder.isRecording ? "Stop Recording" : "Start Recording")
+                        Image(systemName: "play.fill")
+                        Text("Resume")
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 8)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(recorder.isRecording ? .red : .accentColor)
+                .tint(.green)
+            } else {
+                // Pause button
+                Button(action: {
+                    Task {
+                        await recorder.pause()
+                    }
+                }) {
+                    HStack {
+                        Image(systemName: "pause.fill")
+                        Text("Pause")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.yellow)
+
+                // Stop button
+                Button(action: {
+                    Task {
+                        await recorder.stopRecording()
+                    }
+                }) {
+                    HStack {
+                        Image(systemName: "stop.fill")
+                        Text("Stop")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
             }
         }
+    }
+
+    private var startButton: some View {
+        Button(action: {
+            Task {
+                await recorder.startRecording()
+            }
+        }) {
+            HStack {
+                Image(systemName: "record.circle")
+                Text("Start Recording")
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(.accentColor)
     }
 
     private var shouldShowPrimaryButton: Bool {

--- a/EchoNotes/Views/RecordingControlsView.swift
+++ b/EchoNotes/Views/RecordingControlsView.swift
@@ -23,9 +23,7 @@ struct RecordingControlsView: View {
             if recorder.isPaused {
                 // Resume button
                 Button(action: {
-                    Task {
-                        await recorder.resume()
-                    }
+                    Task { await recorder.resume() }
                 }) {
                     HStack {
                         Image(systemName: "play.fill")
@@ -39,9 +37,7 @@ struct RecordingControlsView: View {
             } else {
                 // Pause button
                 Button(action: {
-                    Task {
-                        await recorder.pause()
-                    }
+                    Task { await recorder.pause() }
                 }) {
                     HStack {
                         Image(systemName: "pause.fill")
@@ -52,23 +48,21 @@ struct RecordingControlsView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.yellow)
-
-                // Stop button
-                Button(action: {
-                    Task {
-                        await recorder.stopRecording()
-                    }
-                }) {
-                    HStack {
-                        Image(systemName: "stop.fill")
-                        Text("Stop")
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(.red)
             }
+
+            // Stop button — always visible during recording (paused or not)
+            Button(action: {
+                Task { await recorder.stopRecording() }
+            }) {
+                HStack {
+                    Image(systemName: "stop.fill")
+                    Text("Stop")
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
         }
     }
 


### PR DESCRIPTION
## Summary
Adds pause/resume functionality to the recording system (closes #98). Users can temporarily halt audio capture without ending the session.

## Changes

### RecordingEngine
- Added `isPaused` and `pauseDuration` published properties
- Added `pause()` and `resume()` async methods
- Pause stops both system and mic captures, reset level meters to 0
- Resume restarts both captures and continues writing to the same file
- Pause duration is tracked separately for accurate total timing display
- Live transcription is paused/resumed via TranscriptionManager

### StreamingTranscriber
- Added `isPaused` published property
- `feedSamples()` returns early when paused (no audio queued)
- Added `pause()` and `resume()` methods

### TranscriptionManager
- Added `pauseLiveTranscription()` and `resumeLiveTranscription()` methods

### RecordingControlsView
- During active recording: shows Pause + Stop buttons
- When paused: shows Resume button only
- Color-coded: Pause = yellow, Stop = red, Resume = green

### ActiveRecordingView
- When paused: shows yellow banner with pause icon and resume button
- Timer shows combined duration (recording + pause time)
- Level meters show 0 while paused

## Testing
1. Start recording
2. Click **Pause** — yellow banner appears, meters drop to 0, timer stops
3. Click **Resume** — recording continues, meters come back, timer resumes
4. Click **Stop** — full session (including paused audio) is finalized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pause and resume recording with live paused state and pause-aware timer.
  * Live transcription can be paused and resumed.
  * UI shows a pause banner and distinct Pause / Resume / Stop controls with updated styling.

* **Bug Fixes**
  * Stopping recording now properly clears paused state and resets elapsed time calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->