### PR TITLE
Fix EXC_BREAKPOINT crash in audio buffer callbacks

### DIFF
--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -191,13 +191,17 @@ final class RecordingEngine: ObservableObject {
                 throw error
             }
 
+            // Capture references for use in audio callbacks. These callbacks fire on
+            // background threads (ScreenCaptureKit / AVAudioEngine). Accessing them
+            // through `self` would hit the @MainActor executor check and crash.
+            // Both types use internal locking and are safe to call from any thread.
+            let writerRef = writer
+            let transcriberRef = isLive ? transcriptionManager.streamingTranscriber : nil
+
             // Now that both captures are running, set up buffer callbacks
             systemCapture.onBuffer = { [weak self] buffer in
-                self?.audioWriter?.writeSystemBuffer(buffer)
-                // Feed system audio to streaming transcriber for live mode
-                if isLive {
-                    self?.transcriptionManager.streamingTranscriber.feedSamples(buffer.samples)
-                }
+                writerRef.writeSystemBuffer(buffer)
+                transcriberRef?.feedSamples(buffer.samples)
                 // Throttle level meter updates to ~15fps (66ms minimum interval)
                 Task { @MainActor in
                     guard let self else { return }
@@ -210,7 +214,7 @@ final class RecordingEngine: ObservableObject {
             }
 
             micCapture.onBuffer = { [weak self] buffer in
-                self?.audioWriter?.writeMicBuffer(buffer)
+                writerRef.writeMicBuffer(buffer)
                 // Throttle level meter updates to ~15fps (66ms minimum interval)
                 Task { @MainActor in
                     guard let self else { return }


### PR DESCRIPTION
## Summary

- Fix crash (`EXC_BREAKPOINT` in `swift_task_isCurrentExecutorWithFlagsImpl`) caused by audio buffer callbacks accessing `@MainActor`-isolated stored properties from background threads
- Capture `AudioFileWriter` and `StreamingTranscriber` references as local variables before setting callbacks, so closures access them directly without going through the `@MainActor`-isolated `self` property path

## Root Cause

Audio buffer callbacks from ScreenCaptureKit (`.global(qos: .userInteractive)`) and AVAudioEngine (audio thread) were accessing `self?.audioWriter` and `self?.transcriptionManager.streamingTranscriber` through `@MainActor`-isolated `self`. The Swift runtime inserts a main executor check at those property accesses, which traps when the code is running on a background thread.

The crash appeared intermittently (app ran ~2 days before crashing) because it required a specific timing where the executor check coincided with a SwiftUI view update cycle.

## Changes

**`EchoNotes/App/RecordingEngine.swift`**: Capture `writer` and `streamingTranscriber` as local variables before the callback closures. Both types use internal locking (`@unchecked Sendable` / `nonisolated` with `NSLock`) and are designed for cross-thread access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and memory management in the recording engine to prevent potential issues during audio capture and transcription.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->