### PR TITLE
Fix transcription failure from writer file handle held open

### DIFF
--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -336,14 +336,6 @@ final class RecordingEngine: ObservableObject {
             await systemCapture.stopCapture()
             micCapture.stopCapture()
         }
-
-        // Release buffer callbacks before finalizing the writer. The callbacks
-        // capture a strong reference to the AudioFileWriter; clearing them lets
-        // the writer deallocate after finalize, closing the underlying AVAudioFile
-        // so the recording is readable for transcription.
-        systemCapture.onBuffer = nil
-        micCapture.onBuffer = nil
-
         audioWriter?.finalize()
 
         let url = audioWriter?.outputURL

--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -336,6 +336,14 @@ final class RecordingEngine: ObservableObject {
             await systemCapture.stopCapture()
             micCapture.stopCapture()
         }
+
+        // Release buffer callbacks before finalizing the writer. The callbacks
+        // capture a strong reference to the AudioFileWriter; clearing them lets
+        // the writer deallocate after finalize, closing the underlying AVAudioFile
+        // so the recording is readable for transcription.
+        systemCapture.onBuffer = nil
+        micCapture.onBuffer = nil
+
         audioWriter?.finalize()
 
         let url = audioWriter?.outputURL

--- a/EchoNotes/Audio/AudioFileWriter.swift
+++ b/EchoNotes/Audio/AudioFileWriter.swift
@@ -28,7 +28,7 @@ final class AudioFileWriter: @unchecked Sendable {
     /// Called on write errors (e.g. disk full, buffer overflow). After an error, no further writes are accepted.
     let onError: (@Sendable (Error) -> Void)?
 
-    private let file: AVAudioFile
+    private var file: AVAudioFile?
     private let sampleRate: Double
     private let format: AVAudioFormat
     private let lock = NSLock()
@@ -138,7 +138,7 @@ final class AudioFileWriter: @unchecked Sendable {
         }
 
         do {
-            try file.write(from: pcmBuffer)
+            try file?.write(from: pcmBuffer)
         } catch {
             writeError = error
             onError?(error)
@@ -147,16 +147,18 @@ final class AudioFileWriter: @unchecked Sendable {
 
     /// Flush any remaining samples and close the file.
     ///
-    /// **Known limitation:** There is a race window where capture callbacks may still be
-    /// in-flight when finalize is called (after stopCapture but before callbacks complete).
-    /// Samples arriving during this window may be dropped. A proper fix would require
-    /// synchronization at the capture layer to ensure all callbacks have finished before
-    /// finalize is invoked.
+    /// Explicitly nils the AVAudioFile to close the file handle. This is
+    /// required because audio callbacks may hold a strong reference to the
+    /// writer (to avoid @MainActor isolation violations), preventing dealloc.
     func finalize() {
         // Wait for all in-flight write callbacks to complete before finalizing.
         inflightGroup.wait()
         lock.lock()
-        guard writeError == nil else { lock.unlock(); return }
+        defer { lock.unlock() }
+        guard writeError == nil else {
+            file = nil
+            return
+        }
         // Pad the shorter stream with silence
         let sysRemaining = systemSamples.count - systemOffset
         let micRemaining = micSamples.count - micOffset
@@ -166,7 +168,8 @@ final class AudioFileWriter: @unchecked Sendable {
             while (micSamples.count - micOffset) < maxCount { micSamples.append(0) }
             flushIfReady()
         }
-        lock.unlock()
+        // Close the file handle so transcription can read the file
+        file = nil
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix `com.apple.coreaudio.avfaudio error 1685348671` (`dta?`) that broke all transcription after PR #180
- Make `AudioFileWriter.finalize()` explicitly close the `AVAudioFile` by nilling it

## Root Cause

PR #180 changed audio callbacks to capture `writerRef` (a strong reference to `AudioFileWriter`) instead of accessing it through `self?.audioWriter?`. This fixed the main actor crash, but introduced a regression: the callback closures kept `writerRef` alive after `stopRecording()` called `finalize()` and `cleanup()`.

`AudioFileWriter` holds a `private let file: AVAudioFile` opened for writing. `AVAudioFile` has no close method; it only releases the file handle on dealloc. Since the callbacks kept the writer alive, the file stayed open for writing. When transcription tried to read it with `AVURLAsset` / WhisperKit, CoreAudio failed because the file was still locked.

## Fix

Make `finalize()` explicitly nil out the `AVAudioFile` reference after flushing remaining samples. This closes the file handle immediately regardless of whether the writer object is still held alive by callback closures. Writes after finalize become no-ops via the optional chain (`file?.write`).

The first commit attempted to fix this by nilling `onBuffer` callbacks in `stopRecording()`, which broke recording. That approach was reverted in the second commit in favor of this fix.