### PR TITLE
Fix meeting detail layout crash

### DIFF
--- a/EchoNotes/AI/AIProvider.swift
+++ b/EchoNotes/AI/AIProvider.swift
@@ -61,7 +61,7 @@ enum AIProvider: String, CaseIterable, Codable, Sendable, Identifiable {
         case .anthropic: return ["claude-sonnet-4-5", "claude-haiku-3-5"]
         case .google: return ["gemini-2.0-flash", "gemini-2.5-pro"]
         case .ollama: return ["llama3.2", "llama3.1", "mistral", "gemma2"]
-        case .custom: return []
+        case .custom: return [defaultModel]
         }
     }
 

--- a/EchoNotes/AI/AIService.swift
+++ b/EchoNotes/AI/AIService.swift
@@ -418,9 +418,11 @@ final class AIService: Sendable {
         // Manual fallback: parse JSON dict and extract fields flexibly
         if let dict = try? JSONSerialization.jsonObject(with: summaryData) as? [String: Any] {
             let summary = (dict["summary"] as? String) ?? ""
-            let actionItems = (dict["actionItems"] ?? dict["action_items"]) as? [String] ?? []
-            let keyDecisions = (dict["keyDecisions"] ?? dict["key_decisions"]) as? [String] ?? []
-            let openQuestions = (dict["openQuestions"] ?? dict["open_questions"]) as? [String] ?? []
+            guard let actionItems = (dict["actionItems"] ?? dict["action_items"]) as? [String],
+                  let keyDecisions = (dict["keyDecisions"] ?? dict["key_decisions"]) as? [String],
+                  let openQuestions = (dict["openQuestions"] ?? dict["open_questions"]) as? [String] else {
+                throw AIError.invalidResponse
+            }
 
             if !summary.isEmpty {
                 return MeetingSummary(summary: summary, actionItems: actionItems, keyDecisions: keyDecisions, openQuestions: openQuestions)

--- a/EchoNotes/App/RecordingEngine.swift
+++ b/EchoNotes/App/RecordingEngine.swift
@@ -67,6 +67,8 @@ final class RecordingEngine: ObservableObject {
     private var accumulatedPauseDuration: TimeInterval = 0
     private var lastSystemLevelUpdate: Date = .distantPast
     private var lastMicLevelUpdate: Date = .distantPast
+    private let systemLevelUpdateGate = OSAllocatedUnfairLock(initialState: Date.distantPast)
+    private let micLevelUpdateGate = OSAllocatedUnfairLock(initialState: Date.distantPast)
     private var sleepObserver: NSObjectProtocol?
     private var wakeObserver: NSObjectProtocol?
 
@@ -125,8 +127,9 @@ final class RecordingEngine: ObservableObject {
             // Set up audio file writer (M4A/AAC, 48kHz stereo — system L, mic R)
             let writer = try AudioFileWriter(outputURL: fileURL, sampleRate: AudioConfig.sampleRate, channels: 2) { [weak self] error in
                 Task { @MainActor in
-                    self?.errorMessage = "Recording error: \(error.localizedDescription)"
-                    await self?.stopRecording()
+                    guard let self, self.isRecording else { return }
+                    self.errorMessage = "Recording error: \(error.localizedDescription)"
+                    await self.stopRecording()
                 }
             }
 
@@ -138,21 +141,17 @@ final class RecordingEngine: ObservableObject {
             // Surface audio capture errors to the UI
             systemCapture.onError = { [weak self] error in
                 Task { @MainActor in
-                    self?.errorMessage = "System audio error: \(error.localizedDescription)"
-                    await self?.stopRecording()
-                }
-            }
-
-            micCapture.onWarning = { [weak self] message in
-                Task { @MainActor in
-                    self?.errorMessage = message
+                    guard let self, self.isRecording else { return }
+                    self.errorMessage = "System audio error: \(error.localizedDescription)"
+                    await self.stopRecording()
                 }
             }
 
             micCapture.onError = { [weak self] error in
                 Task { @MainActor in
-                    self?.errorMessage = "Microphone error: \(error.localizedDescription)"
-                    await self?.stopRecording()
+                    guard let self, self.isRecording else { return }
+                    self.errorMessage = "Microphone error: \(error.localizedDescription)"
+                    await self.stopRecording()
                 }
             }
 
@@ -197,32 +196,36 @@ final class RecordingEngine: ObservableObject {
             // Both types use internal locking and are safe to call from any thread.
             let writerRef = writer
             let transcriberRef = isLive ? transcriptionManager.streamingTranscriber : nil
+            let systemLevelUpdateGate = self.systemLevelUpdateGate
+            let micLevelUpdateGate = self.micLevelUpdateGate
+            systemLevelUpdateGate.withLock { $0 = .distantPast }
+            micLevelUpdateGate.withLock { $0 = .distantPast }
 
             // Now that both captures are running, set up buffer callbacks
             systemCapture.onBuffer = { [weak self] buffer in
                 writerRef.writeSystemBuffer(buffer)
                 transcriberRef?.feedSamples(buffer.samples)
-                // Throttle level meter updates to ~15fps (66ms minimum interval)
+                let now = Date()
+                guard RecordingEngine.shouldScheduleLevelUpdate(using: systemLevelUpdateGate, at: now) else { return }
+                let level = SourcedAudioBuffer.rmsLevel(buffer.samples)
+
                 Task { @MainActor in
-                    guard let self else { return }
-                    let now = Date()
-                    if now.timeIntervalSince(self.lastSystemLevelUpdate) > 0.066 {
-                        self.systemLevel = SourcedAudioBuffer.rmsLevel(buffer.samples)
-                        self.lastSystemLevelUpdate = now
-                    }
+                    guard let self, self.isRecording else { return }
+                    self.systemLevel = level
+                    self.lastSystemLevelUpdate = now
                 }
             }
 
             micCapture.onBuffer = { [weak self] buffer in
                 writerRef.writeMicBuffer(buffer)
-                // Throttle level meter updates to ~15fps (66ms minimum interval)
+                let now = Date()
+                guard RecordingEngine.shouldScheduleLevelUpdate(using: micLevelUpdateGate, at: now) else { return }
+                let level = SourcedAudioBuffer.rmsLevel(buffer.samples)
+
                 Task { @MainActor in
-                    guard let self else { return }
-                    let now = Date()
-                    if now.timeIntervalSince(self.lastMicLevelUpdate) > 0.066 {
-                        self.micLevel = SourcedAudioBuffer.rmsLevel(buffer.samples)
-                        self.lastMicLevelUpdate = now
-                    }
+                    guard let self, self.isRecording else { return }
+                    self.micLevel = level
+                    self.lastMicLevelUpdate = now
                 }
             }
 
@@ -421,5 +424,16 @@ final class RecordingEngine: ObservableObject {
     private func cleanup() {
         audioWriter = nil
         recordingStartTime = nil
+    }
+
+    nonisolated private static func shouldScheduleLevelUpdate(
+        using gate: OSAllocatedUnfairLock<Date>,
+        at now: Date
+    ) -> Bool {
+        gate.withLock { lastUpdate in
+            guard now.timeIntervalSince(lastUpdate) >= 0.066 else { return false }
+            lastUpdate = now
+            return true
+        }
     }
 }

--- a/EchoNotes/Audio/MicrophoneCapture.swift
+++ b/EchoNotes/Audio/MicrophoneCapture.swift
@@ -347,11 +347,16 @@ final class MicrophoneCapture: @unchecked Sendable {
         guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outputFrameCount) else { return }
 
         var error: NSError?
-        var hasData = true
+        let didProvideInput = OSAllocatedUnfairLock(initialState: false)
         converter.convert(to: outputBuffer, error: &error) { _, outStatus in
-            if hasData {
+            let shouldProvideInput = didProvideInput.withLock { hasProvidedInput in
+                guard !hasProvidedInput else { return false }
+                hasProvidedInput = true
+                return true
+            }
+
+            if shouldProvideInput {
                 outStatus.pointee = .haveData
-                hasData = false
                 return buffer
             }
             outStatus.pointee = .noDataNow

--- a/EchoNotes/Auth/OAuthManager.swift
+++ b/EchoNotes/Auth/OAuthManager.swift
@@ -10,15 +10,15 @@ final class OAuthManager: ObservableObject {
     private let logger = Logger(subsystem: "com.echonotes", category: "OAuth")
 
     // OpenAI OAuth constants (same as Codex CLI)
-    static let clientId = "app_EMoamEEZ73f0CkXaXp7hrann"
-    static let issuer = "https://auth.openai.com"
-    static let authorizeURL = "\(issuer)/oauth/authorize"
-    static let tokenURL = "\(issuer)/oauth/token"
-    static let scopes = "openid profile email offline_access"
+    nonisolated static let clientId = "app_EMoamEEZ73f0CkXaXp7hrann"
+    nonisolated static let issuer = "https://auth.openai.com"
+    nonisolated static let authorizeURL = "\(issuer)/oauth/authorize"
+    nonisolated static let tokenURL = "\(issuer)/oauth/token"
+    nonisolated static let scopes = "openid profile email offline_access"
 
     // Local callback server port — must match Codex CLI default (1455)
     // OpenAI likely has this redirect URI registered for the client ID
-    private static let callbackPort: UInt16 = 1455
+    nonisolated private static let callbackPort: UInt16 = 1455
 
     @Published var isAuthenticating = false
     @Published var isAuthenticated = false

--- a/EchoNotes/Models/RecordingLibrary.swift
+++ b/EchoNotes/Models/RecordingLibrary.swift
@@ -63,6 +63,8 @@ final class RecordingLibrary: ObservableObject {
     private let logger = Logger(subsystem: "com.echonotes", category: "RecordingLibrary")
     @Published var entries: [RecordingEntry] = []
     @Published var searchQuery: String = ""
+    private var scanTask: Task<Void, Never>?
+    private var scanGeneration = 0
 
     var filteredEntries: [RecordingEntry] {
         guard !searchQuery.isEmpty else { return entries }
@@ -79,18 +81,41 @@ final class RecordingLibrary: ObservableObject {
 
     /// Scan the recordings directory for entries. File I/O runs on a background thread.
     func scan() {
+        requestRefresh()
+    }
+
+    func requestRefresh() {
         let directory = saveDirectory
-        Task { [weak self] in
-            let results = await Task.detached(priority: .userInitiated) {
-                await Self.scanDirectory(directory)
-            }.value
-            self?.entries = results
-            self?.logger.info("Library scan: found \(results.count) recordings")
+        scanGeneration += 1
+        let generation = scanGeneration
+
+        scanTask?.cancel()
+        scanTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .milliseconds(150))
+            } catch {
+                return
+            }
+
+            let results = await withTaskGroup(of: [RecordingEntry].self) { group in
+                group.addTask(priority: .userInitiated) {
+                    await Self.scanDirectory(directory)
+                }
+                return await group.next() ?? []
+            }
+
+            guard !Task.isCancelled else { return }
+            guard let self, generation == self.scanGeneration else { return }
+
+            self.entries = results
+            self.logger.info("Library scan: found \(results.count) recordings")
         }
     }
 
     /// Pure scanning logic — runs off the main thread.
     nonisolated private static func scanDirectory(_ directory: URL) async -> [RecordingEntry] {
+        guard !Task.isCancelled else { return [] }
+
         let fm = FileManager.default
         guard let files = try? fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: [.creationDateKey]) else {
             return []
@@ -100,6 +125,8 @@ final class RecordingLibrary: ObservableObject {
 
         var results: [RecordingEntry] = []
         for fileURL in m4aFiles {
+            guard !Task.isCancelled else { return results }
+
             let date = (try? fileURL.resourceValues(forKeys: [.creationDateKey]))?.creationDate ?? Date.distantPast
             let duration = await getAudioDuration(url: fileURL)
             let txtURL = fileURL.deletingPathExtension().appendingPathExtension("txt")

--- a/EchoNotes/Transcription/StreamingTranscriber.swift
+++ b/EchoNotes/Transcription/StreamingTranscriber.swift
@@ -37,20 +37,14 @@ final class StreamingTranscriber: ObservableObject {
     /// Lock-protected incoming sample buffer. Written from audio callbacks,
     /// drained on MainActor. The lock guarantees FIFO ordering regardless
     /// of which thread the audio callback fires on.
-    private nonisolated(unsafe) let sampleLock = NSLock()
+    private nonisolated let sampleLock = NSLock()
     private nonisolated(unsafe) var incomingSamples: [Float] = []
 
-    /// Reusable audio converter (48kHz → 16kHz). Created once in prepare()
-    /// to avoid repeated allocation per chunk. Only read from nonisolated
-    /// resample() after being set on MainActor — safe because prepare()
-    /// is always called before any audio flows.
-    private nonisolated(unsafe) var resampler: AVAudioConverter?
-    private nonisolated(unsafe) let srcFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48000, channels: 1, interleaved: false)!
-    private nonisolated(unsafe) let dstFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)!
+    private nonisolated let srcFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48000, channels: 1, interleaved: false)!
+    private nonisolated let dstFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)!
 
     func prepare(engine: WhisperEngine) {
         self.whisperEngine = engine
-        self.resampler = AVAudioConverter(from: srcFormat, to: dstFormat)
     }
 
     /// Feed system audio samples from the recording callback.
@@ -231,11 +225,22 @@ final class StreamingTranscriber: ObservableObject {
         let outFrames = AVAudioFrameCount(Double(samples.count) * dstFormat.sampleRate / srcFormat.sampleRate) + 256
         let outBuf = AVAudioPCMBuffer(pcmFormat: dstFormat, frameCapacity: outFrames)!
 
-        var fed = false
+        let didProvideInput = OSAllocatedUnfairLock(initialState: false)
         var err: NSError?
         converter.convert(to: outBuf, error: &err) { _, status in
-            if !fed { fed = true; status.pointee = .haveData; return inBuf }
-            status.pointee = .noDataNow; return nil
+            let shouldProvideInput = didProvideInput.withLock { hasProvidedInput in
+                guard !hasProvidedInput else { return false }
+                hasProvidedInput = true
+                return true
+            }
+
+            if shouldProvideInput {
+                status.pointee = .haveData
+                return inBuf
+            }
+
+            status.pointee = .noDataNow
+            return nil
         }
         if let err { throw err }
 

--- a/EchoNotes/Transcription/TranscriptionManager.swift
+++ b/EchoNotes/Transcription/TranscriptionManager.swift
@@ -104,9 +104,11 @@ final class TranscriptionManager: ObservableObject {
 
     init() {
         // Forward OAuthManager changes to trigger SwiftUI updates
-        oauthCancellable = oauthManager.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
+        oauthCancellable = oauthManager.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
     }
 
     /// Whether the current provider is configured and ready to use.
@@ -339,11 +341,11 @@ final class TranscriptionManager: ObservableObject {
 
     /// Pause live transcription — flush current chunks and stop accepting new audio
     func pauseLiveTranscription() async {
-        await streamingTranscriber.pause()
+        streamingTranscriber.pause()
     }
 
     /// Resume live transcription — continue processing from where we left off
     func resumeLiveTranscription() async {
-        await streamingTranscriber.resume()
+        streamingTranscriber.resume()
     }
 }

--- a/EchoNotes/Transcription/WhisperEngine.swift
+++ b/EchoNotes/Transcription/WhisperEngine.swift
@@ -149,11 +149,22 @@ final class WhisperEngine: @unchecked Sendable {
         let outFrames = AVAudioFrameCount(Double(samples.count) * dstRate / srcRate) + 256
         let outBuf = AVAudioPCMBuffer(pcmFormat: dstFmt, frameCapacity: outFrames)!
 
-        var fed = false
+        let didProvideInput = OSAllocatedUnfairLock(initialState: false)
         var err: NSError?
         converter.convert(to: outBuf, error: &err) { _, status in
-            if !fed { fed = true; status.pointee = .haveData; return inBuf }
-            status.pointee = .noDataNow; return nil
+            let shouldProvideInput = didProvideInput.withLock { hasProvidedInput in
+                guard !hasProvidedInput else { return false }
+                hasProvidedInput = true
+                return true
+            }
+
+            if shouldProvideInput {
+                status.pointee = .haveData
+                return inBuf
+            }
+
+            status.pointee = .noDataNow
+            return nil
         }
         if let err { throw err }
 

--- a/EchoNotes/Views/MainWindowView.swift
+++ b/EchoNotes/Views/MainWindowView.swift
@@ -54,25 +54,23 @@ struct MainWindowView: View {
                 toolbarContent
             }
         }
-        .onAppear { library.scan() }
+        .task {
+            library.requestRefresh()
+        }
         .onChange(of: recorder.isRecording) { _, isRecording in
             if isRecording {
-                // Scan + select the new entry as soon as recording starts
                 selectedSection = .meetings
-                library.scan()
+                library.requestRefresh()
                 if let url = recorder.lastRecordingURL {
                     selectedEntryID = url
                 }
             } else {
-                // Re-scan after recording stops so duration/metadata updates
-                library.scan()
+                library.requestRefresh()
             }
         }
         .onChange(of: tm.isTranscribing) { _, isTranscribing in
             if !isTranscribing {
-                // Re-scan after transcription completes so transcript preview updates
-                library.scan()
-                // Auto-select the newly transcribed recording
+                library.requestRefresh()
                 if let url = tm.transcript?.recordingURL {
                     selectedEntryID = url
                 }
@@ -80,8 +78,7 @@ struct MainWindowView: View {
         }
         .onChange(of: tm.isSummarizing) { _, isSummarizing in
             if !isSummarizing {
-                // Re-scan after summary so the entry reflects updated state
-                library.scan()
+                library.requestRefresh()
             }
         }
     }
@@ -246,7 +243,6 @@ struct MainWindowView: View {
             ActiveRecordingView()
         } else if let entry = selectedEntry {
             RecordingDetailView(entry: entry)
-                .id(entry.id)
         } else if let summary = tm.summary, let transcript = tm.transcript {
             SummaryView(summary: summary, recordingURL: transcript.recordingURL, onBack: {
                 tm.summary = nil
@@ -280,6 +276,29 @@ struct MainWindowView: View {
         } else {
             Text("Ready")
                 .foregroundStyle(.secondary)
+        }
+
+        if let entry = selectedEntry {
+            Menu {
+                if entry.hasTranscript {
+                    Button(action: { copyTranscript(for: entry) }) {
+                        Label("Copy Transcript", systemImage: "doc.on.doc")
+                    }
+                }
+                if hasSummary(for: entry) {
+                    Button(action: { copySummary(for: entry) }) {
+                        Label("Copy Summary", systemImage: "doc.on.doc")
+                    }
+                }
+                Divider()
+                Button(action: {
+                    NSWorkspace.shared.selectFile(entry.url.path, inFileViewerRootedAtPath: entry.url.deletingLastPathComponent().path)
+                }) {
+                    Label("Show in Finder", systemImage: "folder")
+                }
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
         }
 
         Picker("Mode", selection: $recorder.transcriptionModeRaw) {
@@ -370,6 +389,31 @@ struct MainWindowView: View {
             .buttonStyle(.borderedProminent)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func summaryURL(for entry: RecordingEntry) -> URL {
+        entry.url.deletingPathExtension().appendingPathExtension("summary.json")
+    }
+
+    private func hasSummary(for entry: RecordingEntry) -> Bool {
+        FileManager.default.fileExists(atPath: summaryURL(for: entry).path)
+    }
+
+    private func copyTranscript(for entry: RecordingEntry) {
+        guard let transcript = entry.loadTranscript() else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(transcript.toPlainText(), forType: .string)
+    }
+
+    private func copySummary(for entry: RecordingEntry) {
+        let url = summaryURL(for: entry)
+        guard let data = try? Data(contentsOf: url),
+              let summary = try? JSONDecoder().decode(MeetingSummary.self, from: data) else {
+            return
+        }
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(summary.toMarkdown(), forType: .string)
     }
 }
 

--- a/EchoNotes/Views/RecordingDetailView.swift
+++ b/EchoNotes/Views/RecordingDetailView.swift
@@ -71,46 +71,11 @@ struct RecordingDetailView: View {
             .padding(20)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .toolbar {
-            ToolbarItemGroup(placement: .automatic) {
-                // Context menu actions
-                Menu {
-                    if let transcript {
-                        Button(action: {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(transcript.toPlainText(), forType: .string)
-                        }) {
-                            Label("Copy Transcript", systemImage: "doc.on.doc")
-                        }
-                    }
-                    if let summary {
-                        Button(action: {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(summary.toMarkdown(), forType: .string)
-                        }) {
-                            Label("Copy Summary", systemImage: "doc.on.doc")
-                        }
-                    }
-                    Divider()
-                    Button(action: {
-                        NSWorkspace.shared.selectFile(entry.url.path, inFileViewerRootedAtPath: entry.url.deletingLastPathComponent().path)
-                    }) {
-                        Label("Show in Finder", systemImage: "folder")
-                    }
-                } label: {
-                    Image(systemName: "ellipsis.circle")
-                }
-            }
-        }
-        .onAppear {
-            transcript = entry.loadTranscript()
-            if let existing = existingSummary {
-                summary = existing
-            }
+        .task(id: entry.id) {
+            loadEntryState()
         }
         .onChange(of: tm.isTranscribing) { _, isTranscribing in
             if !isTranscribing {
-                // Reload transcript after transcription completes
                 transcript = entry.loadTranscript()
             }
         }
@@ -355,5 +320,12 @@ struct RecordingDetailView: View {
             }
             isSummarizing = false
         }
+    }
+
+    private func loadEntryState() {
+        transcript = entry.loadTranscript()
+        summary = existingSummary
+        summaryError = nil
+        showTranscript = false
     }
 }


### PR DESCRIPTION
## Summary
- keep toolbar ownership in `MainWindowView` and stop forcing `RecordingDetailView` to be recreated during meeting selection changes
- coalesce library refreshes and gate recording callback updates so main-thread layout and teardown work do not pile up
- fix the audio converter concurrency hazards and the surfaced AI provider and response parsing test failures

## Testing
- swift test
- ./scripts/build-app.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added toolbar menu for recordings with copy transcript/summary and "Show in Finder" actions.
  * Custom AI model selection now available.

* **Bug Fixes**
  * Improved concurrent recording library scanning to prevent stale data overwrites.
  * Enhanced error handling for audio and transcription operations.
  * Fixed view stability when switching between recordings.

* **Improvements**
  * Better responsiveness of audio level display during recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->