### PR TITLE
Remount root view on wake to fix post-sleep Button crash

### DIFF
--- a/EchoNotes/App/EchoNotesApp.swift
+++ b/EchoNotes/App/EchoNotesApp.swift
@@ -5,6 +5,14 @@ import AppKit
 struct EchoNotesApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
+    /// Bumped after the system wakes from sleep to force a fresh SwiftUI view
+    /// hierarchy. macOS 26 SwiftUI/AttributeGraph state can become stale across
+    /// long sleep cycles, causing EXC_BAD_ACCESS in MainActor.assumeIsolated
+    /// when the first Button is tapped after wake. Remounting clears that state.
+    /// Owned-state classes (RecordingEngine, TranscriptionManager, etc.) live on
+    /// AppDelegate, so the rebuild only resets view-local @State.
+    @State private var contentID = UUID()
+
     var body: some Scene {
         WindowGroup {
             MainWindowView()
@@ -12,6 +20,12 @@ struct EchoNotesApp: App {
                 .environment(appDelegate.recorder.transcriptionManager)
                 .environment(appDelegate.recorder.transcriptionManager.modelManager)
                 .environment(appDelegate.library)
+                .id(contentID)
+                .onReceive(
+                    NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didWakeNotification)
+                ) { _ in
+                    contentID = UUID()
+                }
         }
         .defaultSize(width: 960, height: 640)
     }


### PR DESCRIPTION
## Background

#183 migrated to `@Observable` to remove a Combine-bridge reentrancy that I believed was the root cause of the Button-tap `EXC_BAD_ACCESS`. A new crash report on the post-migration build (binary UUID `62b1f01a...`) shows the same stack:

```
objc_msgSend + 56                          <- isa load returns 0
swift_getObjectType
swift_task_isMainExecutorImpl
MainActor.assumeIsolated
closure in _ButtonGesture.internalBody
```

The crashing app had been alive for ~30 hours through multiple sleep/wake cycles. `x0` points into `AG::data::_shared_table_bytes` (AttributeGraph internal storage) and the isa read at that address is null.

## Root cause (revised)

SwiftUI's gesture machinery caches the executor identity for Button actions in AttributeGraph data. Across long sleep cycles on macOS 26, that cached state can become invalid. The first Button tap after wake reads the stale entry and the runtime's main-actor identity check explodes. There is no app-level API to repair the cache in place.

The `@Observable` migration in #183 was still worthwhile (correct modern API, removes the reentrant `objectWillChange`), but it doesn't address this failure mode.

## Fix

Throw out and rebuild SwiftUI's view tree when `NSWorkspace.didWakeNotification` fires. This is done by toggling a `@State` UUID applied via `.id(contentID)` to the root content. Rebuilding the view subtree forces SwiftUI to discard its cached gesture/AttributeGraph state and recreate it from scratch.

The persistent data layer (`RecordingEngine`, `TranscriptionManager`, `RecordingLibrary`, `ModelManager`) lives on `AppDelegate` and survives the remount. The user only loses view-local `@State` (selected meeting, expanded transcript section).

## Test plan

- `./scripts/build-app.sh` passes.
- Manual: sleep the laptop, wait, wake, click Record. Should no longer crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed app refresh behavior when Mac wakes from sleep.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->